### PR TITLE
hardcode naming authority

### DIFF
--- a/firebase_to_xml/firebase_to_xml.py
+++ b/firebase_to_xml/firebase_to_xml.py
@@ -93,7 +93,7 @@ def record_json_to_yaml(record):
 
     record_yaml = {
         'metadata': {
-            'naming_authority': record.get('namingAuthority'),
+            'naming_authority': 'ca.coos',
             'identifier': record.get('identifier'),
             'language': record.get('language'),
             'maintenance_note': record.get('maintenance'),

--- a/src/components/FormComponents/MetadataTab.jsx
+++ b/src/components/FormComponents/MetadataTab.jsx
@@ -50,22 +50,7 @@ const MetadataTab = ({
         disabled={disabled}
       />
     </Paper>
-
     <Paper style={paperClass}>
-      <Typography>
-        <En>What is the naming authority?</En>
-        <Fr>Qu'est-ce que l'autorité de désignation?</Fr>
-      </Typography>
-      <BilingualTextInput
-        name="namingAuthority"
-        value={record.namingAuthority}
-        onChange={handleInputChange}
-        multiline
-        disabled={disabled}
-      />
-    </Paper>
-
-    <Paper style={paperClassValidate("limitations")}>
       <Typography>
         <En>
           What are the limitations affecting the fitness for use of the resource
@@ -75,7 +60,6 @@ const MetadataTab = ({
           Quelles sont les limites qui influent sur l'aptitude à l'utilisation
           de la ressource ou des métadonnées?
         </Fr>
-        <RequiredMark />
       </Typography>
       <BilingualTextInput
         name="limitations"


### PR DESCRIPTION
This removes the option to input a naming authority for the identifier. Since the identifier is a UUID provided by the form, this PR hardcodes it to 'ca.cioos'.

Also makes 'use limitations' optional

Fixes #48
Fixes #46