### PR TITLE
fix unicode output, remove .env setup

### DIFF
--- a/firebase_to_xml/.env
+++ b/firebase_to_xml/.env
@@ -1,4 +1,0 @@
-# FIREBASE_OAUTH2_KEY = keys/cioos-metadata-form-firebase-adminsdk-44g1h-2a894581ec.json
-# FIREBASE_OUTPUT_FOLDER = output
-# FIREBASE_REGION = pacific
-

--- a/firebase_to_xml/README.md
+++ b/firebase_to_xml/README.md
@@ -9,8 +9,6 @@ To generate a new key:
 
 - Keys can be managed at <https://console.cloud.google.com/iam-admin/serviceaccounts/details/108735728189650899572?authuser=0&project=cioos-metadata-form>
 
-- (optional) update .env with the path to your key. Otherwise you will have to supply this path at command line
-
 ## Installation
 
 Create and activate virtual enviroment
@@ -31,9 +29,6 @@ Update
 ```bash
 pip install --upgrade .
 ```
-
-- To set enviroment variables to be used by the script edit the .env file.
-  Any command passed on the command line can also be set in the enviroment variable
 
 ## Running
 

--- a/firebase_to_xml/firebase_to_xml.py
+++ b/firebase_to_xml/firebase_to_xml.py
@@ -7,7 +7,6 @@ the metadata-xml module.
 
 
 import json
-import os
 import sys
 import pprint
 import argparse
@@ -29,16 +28,15 @@ def main():
         description='Convert firebase metadata form to xml and optionaly yaml')
 
     parser.add_argument('--key',
-                        default=os.getenv("FIREBASE_OAUTH2_KEY"),
-                        help='Path to firebase OAuth2 key')
+                        required=True,
+                        help='Path to firebase OAuth2 key file')
     parser.add_argument('--out',
-                        default=os.getenv("FIREBASE_OUTPUT_FOLDER") or '',
+                        default='.',
                         help='Folder to save xml')
     parser.add_argument('--yaml', action='store_true',
-                        default=os.getenv("FIREBASE_OUTPUT_YAML") or False,
                         help='Whether to output yaml file as well as xml')
     parser.add_argument('--region',
-                        default=os.getenv("FIREBASE_REGION"),
+                        required=True,
                         choices=['pacific', 'stlaurent', 'atlantic'])
 
     args = vars(parser.parse_args())
@@ -75,7 +73,7 @@ def main():
             if also_save_yaml:
                 filename = f'{xml_directory}/{name}.yaml'
                 file = open(filename, "w")
-                file.write(yaml.dump(record_yaml))
+                file.write(yaml.dump(record_yaml, allow_unicode=True))
 
             # render xml template and write to file
             xml = metadata_to_xml(record_yaml)
@@ -109,7 +107,7 @@ def record_json_to_yaml(record):
                      record.get('map', {}).get('south'),
                      record.get('map', {}).get('east'),
                      record.get('map', {}).get('north')],
-            'polygon': record.get('map', {}).get('polygon'),
+            'polygon': record.get('map', {}).get('polygon', ''),
             'vertical': [record.get('verticalExtentMin'),
                          record.get('verticalExtentMax')],
         },
@@ -127,8 +125,8 @@ def record_json_to_yaml(record):
         },
         'contact': [
             {
-                'roles': [x.get('role')],
-                'organization':{
+                'roles': x.get('role'),
+                'organization': {
                     'name': x.get('orgName'),
                     'url': x.get('orgURL'),
                     'address': x.get('orgAdress'),


### PR DESCRIPTION
This update:
 - fixes the unicode output in the yaml. 
 - updates the 'role' section to reflect the multiple role changes we've made
 - removes the .env file to simplify making sure required fields are supplied with argparse