### PR TITLE
admin and reviewer switch to comma separated list

### DIFF
--- a/src/components/Pages/Admin.jsx
+++ b/src/components/Pages/Admin.jsx
@@ -14,6 +14,7 @@ import { En, Fr, I18n } from "../I18n";
 import FormClassTemplate from "./FormClassTemplate";
 
 const unique = (arr) => [...new Set(arr)];
+const cleanArr = (arr) => unique(arr.map((e) => e.trim()).filter((e) => e));
 
 class Admin extends FormClassTemplate {
   constructor(props) {
@@ -41,8 +42,8 @@ class Admin extends FormClassTemplate {
         permissionsRef.on("value", (permissionsFirebase) => {
           const permissions = permissionsFirebase.toJSON();
 
-          const admins = Object.values(permissions.admins || {});
-          const reviewers = Object.values(permissions.reviewers || {});
+          const admins = permissions.admins.split(",");
+          const reviewers = permissions.reviewers.split(",");
 
           this.setState({
             admins,
@@ -60,11 +61,12 @@ class Admin extends FormClassTemplate {
     const { region } = match.params;
 
     const { reviewers, admins } = this.state;
+
     if (auth.currentUser) {
       const dbRef = firebase.database().ref(region).child("permissions");
 
-      dbRef.child("admins").set(unique(admins));
-      dbRef.child("reviewers").set(unique(reviewers));
+      dbRef.child("admins").set(cleanArr(admins).join());
+      dbRef.child("reviewers").set(cleanArr(reviewers).join());
     }
   }
 
@@ -128,7 +130,9 @@ class Admin extends FormClassTemplate {
                 fullWidth
                 value={reviewers.join("\n")}
                 onChange={(e) =>
-                  this.setState({ reviewers: e.target.value.split("\n") })
+                  this.setState({
+                    reviewers: e.target.value.split("\n"),
+                  })
                 }
               />
             </Grid>

--- a/src/providers/UserProvider.jsx
+++ b/src/providers/UserProvider.jsx
@@ -52,12 +52,11 @@ class UserProvider extends FormClassTemplate {
         permissionsRef.on("value", (permissionsFB) => {
           const permissions = permissionsFB.toJSON();
 
-          const admins = permissions && Object.values(permissions.admins || {});
-          const reviewers =
-            permissions && Object.values(permissions.reviewers || {});
+          const admins = permissions?.admins || "";
+          const reviewers = permissions?.reviewers || "";
 
-          const isAdmin = admins && admins.includes(email);
-          const isReviewer = reviewers && reviewers.includes(email);
+          const isAdmin = admins.includes(email);
+          const isReviewer = reviewers.includes(email);
 
           this.setState({
             admins,


### PR DESCRIPTION
This is a small change to how the list of admins/reviewers is stored, changes it to a comma separated string. eg:
```json
{
  "permissions": {
    "admins": "a@b.ca,e@f.ca,g@h.ca",
    "reviewers": "e@f.ca"
  }
}
```
This will make it easier to work with Firebase security rules (See #24).

This requires a small change to the database before it will work properly