### PR TITLE
display error screen instead of all white

### DIFF
--- a/src/components/BaseLayout.jsx
+++ b/src/components/BaseLayout.jsx
@@ -9,6 +9,7 @@ import Contacts from "./Pages/ContactsSaved";
 import Login from "./Pages/Login";
 import NavDrawer from "./NavDrawer";
 import MetadataForm from "./Pages/MetadataForm";
+import ErrorBoundary from "./Pages/ErrorBoundary";
 import EditContact from "./FormComponents/EditSavedContact";
 import Reviewer from "./Pages/Reviewer";
 import Admin from "./Pages/Admin";
@@ -41,35 +42,37 @@ const Pages = ({ match }) => {
       ) : (
         <RegionLogo>
           {loggedIn ? (
-            <Switch>
-              <Route path={`${match.path}/`} exact component={Submissions} />
-              <Route path={`${match.path}/new`} component={MetadataForm} />
-              <Route
-                path={`${match.path}/contacts/:contactID`}
-                component={EditContact}
-              />
-              <Route
-                path={`${match.path}/contacts/new`}
-                component={EditContact}
-              />
-              <Route path={`${match.path}/contacts`} component={Contacts} />
-              <Route
-                path={`${match.path}/:userID/:recordID`}
-                component={MetadataForm}
-              />
-              <Route
-                path={`${match.path}/submissions`}
-                component={Submissions}
-              />
-              <Route path={`${match.path}/published`} component={Published} />
-              <Route path={`${match.path}/reviewer`} component={Reviewer} />
-              <Route path={`${match.path}/admin`} component={Admin} />
-              <Route
-                path={`${match.path}/sentry-test`}
-                component={SentryTest}
-              />
-              <Route path="*" component={NotFound} />
-            </Switch>
+            <ErrorBoundary>
+              <Switch>
+                <Route path={`${match.path}/`} exact component={Submissions} />
+                <Route path={`${match.path}/new`} component={MetadataForm} />
+                <Route
+                  path={`${match.path}/contacts/:contactID`}
+                  component={EditContact}
+                />
+                <Route
+                  path={`${match.path}/contacts/new`}
+                  component={EditContact}
+                />
+                <Route path={`${match.path}/contacts`} component={Contacts} />
+                <Route
+                  path={`${match.path}/:userID/:recordID`}
+                  component={MetadataForm}
+                />
+                <Route
+                  path={`${match.path}/submissions`}
+                  component={Submissions}
+                />
+                <Route path={`${match.path}/published`} component={Published} />
+                <Route path={`${match.path}/reviewer`} component={Reviewer} />
+                <Route path={`${match.path}/admin`} component={Admin} />
+                <Route
+                  path={`${match.path}/sentry-test`}
+                  component={SentryTest}
+                />
+                <Route path="*" component={NotFound} />
+              </Switch>
+            </ErrorBoundary>
           ) : (
             <Login />
           )}

--- a/src/components/Pages/ErrorBoundary.jsx
+++ b/src/components/Pages/ErrorBoundary.jsx
@@ -1,0 +1,49 @@
+import React, { Component } from "react";
+import * as Sentry from "@sentry/react";
+import { I18n, En, Fr } from "../I18n";
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error(error, errorInfo);
+    Sentry.captureException(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <h1>
+            <I18n>
+              <En>Something went wrong!</En>
+              <Fr>Un problème s'est produit!</Fr>
+            </I18n>
+          </h1>
+          <h5>
+            <I18n>
+              <En>
+                The developers have been notified and are working to resolve the
+                issue.
+              </En>
+              <Fr>
+                Les développeurs ont été avertis et s'efforçent de résoudre le
+                problème.
+              </Fr>
+            </I18n>
+          </h5>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
Currently the user sees a white screen when something goes wrong.  This PR uses error boundaries in React to render an error page

![Screen Shot 2021-10-04 at 2 04 43 PM](https://user-images.githubusercontent.com/26209011/135924798-9eae2ed6-4634-4853-8a6a-4a2f5a8727a0.png)
 
