### PR TITLE
Fix typos and small bugs

### DIFF
--- a/src/components/Tabs/ContactTab.jsx
+++ b/src/components/Tabs/ContactTab.jsx
@@ -84,8 +84,8 @@ const ContactTab = ({
                 <En>
                   It is important to include all individuals from the chain of
                   attribution to ensure all involved parties are credited
-                  appropriately for their role in creating this dataset Saved
-                  contacts can be selected from the list below If you have any
+                  appropriately for their role in creating this dataset. Saved
+                  contacts can be selected from the list below. If you have any
                   saved contacts you can select them from the list.
                 </En>
                 <Fr>

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -36,7 +36,7 @@ const IdentificationTab = ({
   );
   const languageUpperCase = language.toUpperCase();
 
-  const CatalogueLink = (lang) => (
+  const CatalogueLink = ({lang}) => (
     <a
       href={regionInfo.catalogueURL[lang]}
       target="_blank"
@@ -52,10 +52,6 @@ const IdentificationTab = ({
       b.title[language] || a.title.en,
       language
     )
-  );
-
-  const licenseText = Object.values(licensesSorted).map(
-    (l) => l.title[language] || l.title.en
   );
 
   return (
@@ -127,7 +123,7 @@ const IdentificationTab = ({
                 for this dataset in the {regionInfo.catalogueTitle.en}. Browsing
                 datasets at <CatalogueLink lang="en" /> can help provide a sense
                 of the type of descriptions that are typically used for this
-                section of the profile. As a general rule, this section should
+                section of the record. As a general rule, this section should
                 be worded with as little jargon as possible to give potential
                 users an understanding of your dataset.
                 <br />
@@ -513,13 +509,12 @@ const IdentificationTab = ({
             </I18n>
           </SupplementalText>
         </QuestionText>
-        {record.license}
         <SelectInput
           value={record.license}
           onChange={handleUpdateRecord("license")}
-          optionLabels={licenseText.map((l) => (
+          optionLabels={licensesSorted.map((l) => (
             <span>
-              {l}
+              {l.title[language] || l.title.en}
 
               <Tooltip
                 title={

--- a/src/components/Tabs/SpatialTab.jsx
+++ b/src/components/Tabs/SpatialTab.jsx
@@ -112,7 +112,7 @@ const SpatialTab = ({ disabled, record, handleUpdateRecord, updateRecord }) => {
               <I18n>
                 <En>
                   Depth positive: Depth is recorded with positive values (i.e. a
-                  maximum value of 150m implies 150m below the surface).
+                  maximum value of 150m implies 150m below sea level).
                 </En>
                 <Fr>
                   Profondeur positive: La profondeur est enregistrée avec des
@@ -125,13 +125,12 @@ const SpatialTab = ({ disabled, record, handleUpdateRecord, updateRecord }) => {
             <div>
               <I18n>
                 <En>
-                  Height positive: Height is the elevation from sea level (i.e. a
+                  Height Positive: Altitude is the elevation from sea level (i.e. a
                   maximum value of 150m implies 150m above sea level).
                 </En>
                 <Fr>
-                  Hauteur positive: La profondeur est l'élévation depuis le fond
-                  marin (c'est-à-dire une valeur maximale de 150 m implique 150
-                  m au-dessus du fond marin)
+                  Hauteur positive: L'altitude est l'altitude par rapport au niveau de la mer
+                  (c'est-à-dire qu'une valeur maximale de 150 m implique 150 m au-dessus du niveau de la mer).
                 </Fr>
               </I18n>
               <OpenEPSGDefn url="https://epsg.io/5829" />

--- a/src/components/Tabs/StartTab.jsx
+++ b/src/components/Tabs/StartTab.jsx
@@ -40,10 +40,10 @@ const StartTab = ({ disabled }) => {
             <En>
               Welcome to the {regionInfo.title.en} Metadata Entry Tool, the
               first step in making your data discoverable and accessible through
-              CIOOS. This information will be used to create a metadata profile
+              CIOOS. This information will be used to create a metadata record
               for your dataset that will allow it to be searchable through the{" "}
               {regionInfo.catalogueTitle.en}. Please fill out each field with as
-              much detail as possible. The metadata profile will help describe
+              much detail as possible. The metadata record will help describe
               this dataset for others to determine if it is relevant for their
               work and ensure it is interoperable with other databases and
               systems.
@@ -54,7 +54,7 @@ const StartTab = ({ disabled }) => {
               Bienvenue dans l’outil de saisie de métadonnées du{" "}
               {regionInfo.title.fr}! Ceci constitue la première étape pour
               rendre vos données accessibles et découvrables via notre
-              plateforme. Ces renseignements serviront à créer un profil de
+              plateforme. Ces renseignements serviront à créer un enregistrement de 
               métadonnées pour votre jeu de données, facilitant ainsi sa
               découverte dans le {regionInfo.catalogueTitle.fr} et le rendant
               interopérable avec d’autres systèmes de diffusion. Veuillez

--- a/src/isoCodeLists.js
+++ b/src/isoCodeLists.js
@@ -58,7 +58,7 @@ export const roleCodes = {
   },
   coAuthor: {
     title: { en: "Coauthor", fr: "Co-auteur" },
-    text: { en: "Parti qui est l'auteur de la ressource" },
+    text: { en:"Party who jointly authors the resource", fr: "Partie qui est l'auteur conjoint de la ressource" },
   },
 
   collaborator: {
@@ -175,14 +175,6 @@ export const roleCodes = {
         "Partie qui a un intérêt dans la ressource ou l'utilisation de la ressource",
     },
   },
-  // This option doesn't seem appropriate to the form
-  // user: {
-  //   title: { en: "User", fr: "Utilisateur" },
-  //   text: {
-  //     en: "Party who uses the resource",
-  //     fr: "Partie qui utilise la ressource",
-  //   },
-  // },
 };
 
 export const progressCodes = {


### PR DESCRIPTION
This are mostly issues brought to me by @timvdstap and Metadata TT . Typos and a couple small bug fixes:

 - license links not working
 - height/depth clarification on spatial page
 - change wording from 'profile' to 'record' for consistency
