### PR TITLE
fix module requirements

### DIFF
--- a/firebase_to_xml/setup.py
+++ b/firebase_to_xml/setup.py
@@ -19,6 +19,6 @@ setup(
         "google-auth",
         "google-oauth",
         "python-dotenv",
-        "metadata_xml@git+git://github.com/cioos-siooc/metadata-xml.git",
+        "metadata_xml@git+https://github.com/cioos-siooc/metadata-xml.git",
     ],
 )


### PR DESCRIPTION
fix pip install error
```
Running command git clone -q git://github.com/cioos-siooc/metadata-xml.git /tmp/pip-install-5di5gvtz/metadata-xml_c26e70b099084c6aace0b70d935c8840
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```