### PR TITLE
Updated text for the IdentificationTab and ResourcesTab

### DIFF
--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -427,6 +427,27 @@ const IdentificationTab = ({
               Laissez le champs vide si le jeu de données n'a pas a été révisé.
             </Fr>
           </I18n>
+          <SupplementalText>
+                <I18n>
+                  <En>
+                    <p>
+                      Please note that this field does not need to be populated 
+                      or updated when revisions are made to the metadata, but 
+                      rather when a new version of the data file or package 
+                      becomes available, i.e. for time-series data.
+                    </p>
+                  </En>
+                  <Fr>
+                    <p>
+                      Veuillez noter que ce champ n'a pas besoin d'être rempli 
+                      ou mis à jour lorsque des révisions sont apportées aux 
+                      métadonnées, mais plutôt lorsqu'une nouvelle version du 
+                      fichier ou du paquet de données devient disponible, 
+                      c'est-à-dire pour les données de séries chronologiques.
+                    </p>
+                  </Fr>
+                </I18n>
+              </SupplementalText>
         </QuestionText>
         <DateInput
           name="dateRevised"

--- a/src/components/Tabs/ResourcesTab.jsx
+++ b/src/components/Tabs/ResourcesTab.jsx
@@ -34,7 +34,7 @@ const ResourcesTab = ({ disabled, record, updateRecord }) => {
                   <li>ERDDAP datasets</li>
                   <li>images</li>
                 </ul>
-                At least one item is required.
+                At least one item is required. A Resource URL can link to a (compressed) data package or folder.
               </En>
               <Fr>
                 Voici quelques exemples de ressources :
@@ -46,7 +46,7 @@ const ResourcesTab = ({ disabled, record, updateRecord }) => {
                   <li>Jeux de données ERDDAP</li>
                   <li>Images</li>
                 </ul>
-                Au moins une ressource est requise.
+                Au moins une ressource est requise. Une URL de ressource peut être liée à un paquet de données (compressé) ou à un dossier.
               </Fr>
             </I18n>
           </SupplementalText>


### PR DESCRIPTION
Hey guys,

I updated to some guidance text in the identificationTab and ResourcesTab to (hopefully) help users better understand that resource URLs don't necessarily need to link to individual files, and that 'data revised' field does not need to be populated / updated for metadata.