### PR TITLE
add projects option

### DIFF
--- a/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
+++ b/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
@@ -117,6 +117,7 @@ def record_json_to_yaml(record):
             "temporal_begin": record.get("dateStart"),
             "temporal_end": record.get("dateEnd"),
             "status": record.get("status"),
+            "projects": record.get("projects"),
             "progress_code": record.get("progress"),
         },
         "contact": [

--- a/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
+++ b/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
@@ -117,7 +117,7 @@ def record_json_to_yaml(record):
             "temporal_begin": record.get("dateStart"),
             "temporal_end": record.get("dateEnd"),
             "status": record.get("status"),
-            "projects": record.get("projects"),
+            "project": record.get("projects"),
             "progress_code": record.get("progress"),
         },
         "contact": [

--- a/src/components/Pages/MetadataForm.jsx
+++ b/src/components/Pages/MetadataForm.jsx
@@ -32,7 +32,10 @@ import SubmitTab from "../Tabs/SubmitTab";
 import { auth } from "../../auth";
 import firebase from "../../firebase";
 import { firebaseToJSObject, trimStringsInObject } from "../../utils/misc";
-import { submitRecord } from "../../utils/firebaseRecordFunctions";
+import {
+  submitRecord,
+  getRegionProjects,
+} from "../../utils/firebaseRecordFunctions";
 import { UserContext } from "../../providers/UserProvider";
 import { percentValid } from "../../utils/validate";
 import tabs from "../../utils/tabs";
@@ -94,6 +97,7 @@ class MetadataForm extends FormClassTemplate {
     super(props);
 
     this.state = {
+      projects: [],
       record: getBlankRecord(),
 
       // contacts saved by user (not the ones saved in the record)
@@ -128,6 +132,8 @@ class MetadataForm extends FormClassTemplate {
         const recordUserID = isNewRecord ? loggedInUserID : match.params.userID;
         const loggedInUserOwnsRecord = loggedInUserID === recordUserID;
         const { isReviewer } = this.context;
+
+        this.setState({ projects: await getRegionProjects(region) });
         let editorInfo;
         // get info of the person openeing the record
         const editorDataRef = firebase
@@ -349,6 +355,7 @@ class MetadataForm extends FormClassTemplate {
       highlightMissingRequireFields,
       loggedInUserCanEditRecord,
       saveIncompleteRecordModalOpen,
+      projects,
     } = this.state;
 
     if (!record) {
@@ -366,7 +373,6 @@ class MetadataForm extends FormClassTemplate {
       updateRecord: this.updateRecord,
     };
     const percentValidInt = Math.round(percentValid(record) * 100);
-
     return loading ? (
       <CircularProgress />
     ) : (
@@ -504,7 +510,7 @@ class MetadataForm extends FormClassTemplate {
           <StartTab {...tabProps} />
         </TabPanel>
         <TabPanel value={tabIndex} index="identification">
-          <IdentificationTab {...tabProps} />
+          <IdentificationTab {...tabProps} projects={projects} />
         </TabPanel>
         <TabPanel value={tabIndex} index="spatial">
           <SpatialTab {...tabProps} />

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -28,6 +28,7 @@ const IdentificationTab = ({
   record,
   handleUpdateRecord,
   updateRecord,
+  projects,
 }) => {
   const { language, region } = useParams();
   const regionInfo = regions[region];
@@ -117,6 +118,34 @@ const IdentificationTab = ({
         />
       </Paper>
 
+      {projects.length ? (
+        <Paper style={paperClass}>
+          <QuestionText>
+            <I18n>
+              <En>
+                What are the projects that this record is part of? To add a
+                project, email{" "}
+              </En>
+              <Fr>
+                Quels sont les projets dont ce disque fait partie? Pour ajouter
+                un projet, e-mail{" "}
+              </Fr>
+            </I18n>
+            <a href={`mailto:${regionInfo.email}`}>{regionInfo.email}</a>.
+          </QuestionText>
+          <CheckBoxList
+            value={record.projects || []}
+            labelSize={6}
+            onChange={updateRecord("projects")}
+            options={projects}
+            optionLabels={projects}
+            disabled={disabled}
+          />
+        </Paper>
+      ) : (
+        <div />
+      )}
+
       <Paper style={paperClass}>
         <QuestionText>
           <I18n>
@@ -164,9 +193,14 @@ const IdentificationTab = ({
               </En>
 
               <Fr>
-                Cette description correspond au résumé de votre jeu de données lorsqu’il sera publié dans le{" "}
-                {regionInfo.catalogueTitle.fr} <CatalogueLink lang="fr" />. Pour vous aider à rédiger ce résumé,
-                vous pouvez vous inspirer d’autres jeux de données déjà publiés dans le catalogue. Ce champ doit être compris par tout type d’utilisateur, nous vous recommandons un maximum de 500 mots, l’utilisation d’un langage accessible et de limiter l’utilisation de vocabulaire de type jargon.
+                Cette description correspond au résumé de votre jeu de données
+                lorsqu’il sera publié dans le {regionInfo.catalogueTitle.fr}{" "}
+                <CatalogueLink lang="fr" />. Pour vous aider à rédiger ce
+                résumé, vous pouvez vous inspirer d’autres jeux de données déjà
+                publiés dans le catalogue. Ce champ doit être compris par tout
+                type d’utilisateur, nous vous recommandons un maximum de 500
+                mots, l’utilisation d’un langage accessible et de limiter
+                l’utilisation de vocabulaire de type jargon.
                 <br />
                 <br />
                 Suggestion de points à aborder dans votre résumé:
@@ -176,19 +210,26 @@ const IdentificationTab = ({
                       <b>Quoi</b>: Les variables qui ont été mesurées
                     </li>
                     <li>
-                      <b>Quand</b>: Couverture temporelle de la donnée, fréquence de la mesure/observation
+                      <b>Quand</b>: Couverture temporelle de la donnée,
+                      fréquence de la mesure/observation
                     </li>
                     <li>
-                      <b>Où</b>: Couverture spatiale de la donnée, nom/lieu des sites d’échantillonnages,  déplacement enregistrés d’un capteur, laboratoire, etc.
+                      <b>Où</b>: Couverture spatiale de la donnée, nom/lieu des
+                      sites d’échantillonnages, déplacement enregistrés d’un
+                      capteur, laboratoire, etc.
                     </li>
                     <li>
-                      <b>Comment</b>: Équipement, procédures, protocoles, calibration, assurance/contrôle de la qualité
+                      <b>Comment</b>: Équipement, procédures, protocoles,
+                      calibration, assurance/contrôle de la qualité
                     </li>
                     <li>
                       <b>Qui</b>: Participants, membres du personnel
                     </li>
                     <li>
-                      <b>Pourquoi</b>: Quelques lignes pour décrire le contexte dans lequel les données ont été échantillonnées et comment elles permettent de répondre à la problématique (p. ex: quelles informations peuvent-elles apporter)
+                      <b>Pourquoi</b>: Quelques lignes pour décrire le contexte
+                      dans lequel les données ont été échantillonnées et comment
+                      elles permettent de répondre à la problématique (p. ex:
+                      quelles informations peuvent-elles apporter)
                     </li>
                   </ul>
                 </div>
@@ -215,7 +256,9 @@ const IdentificationTab = ({
             <Fr>
               Veuillez sélectionner toutes les variables océaniques essentielles
               contenues dans ce jeu de données. Survolez une variable pour voir
-              sa définition ou cliquez sur l’icône <OpenInNew /> pour accéder à la définition complète du Système d’Observatoire Global des Océans (GOOS).
+              sa définition ou cliquez sur l’icône <OpenInNew /> pour accéder à
+              la définition complète du Système d’Observatoire Global des Océans
+              (GOOS).
             </Fr>
           </I18n>
           <RequiredMark passes={validateField(record, "eov")} />
@@ -223,7 +266,8 @@ const IdentificationTab = ({
             <I18n>
               <En>If none of these apply you can select Other.</En>
               <Fr>
-                Si aucune de ces variables ne vous semble pertinente, vous pouvez sélectionner « Autre ».
+                Si aucune de ces variables ne vous semble pertinente, vous
+                pouvez sélectionner « Autre ».
               </Fr>
             </I18n>
           </SupplementalText>
@@ -271,7 +315,7 @@ const IdentificationTab = ({
                       </IconButton>
                     )}
                     {e.emerging && (
-                      <IconButton onClick={() => { }}>
+                      <IconButton onClick={() => {}}>
                         <Tooltip
                           title={
                             <I18n
@@ -325,10 +369,19 @@ const IdentificationTab = ({
                   </En>
                   <Fr>
                     <p>
-                      Les mots clés sont un moyen efficace de catégoriser vos données pour permettre aux utilisateurs ou à d'autres systèmes d’accéder à tous les jeux de données partageant une même caractéristique.
+                      Les mots clés sont un moyen efficace de catégoriser vos
+                      données pour permettre aux utilisateurs ou à d'autres
+                      systèmes d’accéder à tous les jeux de données partageant
+                      une même caractéristique.
                     </p>
                     <p>
-                      Vous pouvez choisir un mot clé prédéfini (liste déroulante) en français puis cliquer sur le bouton de traduction. Vous pouvez aussi créer votre propre mot clé en rédigeant un texte libre en anglais ou en français (vérifiez toujours si son équivalent existe dans la liste déroulante afin de diminuer le risque d’écriture multiple d’un même mot clé -ex: phoque Vs Phoques-).
+                      Vous pouvez choisir un mot clé prédéfini (liste
+                      déroulante) en français puis cliquer sur le bouton de
+                      traduction. Vous pouvez aussi créer votre propre mot clé
+                      en rédigeant un texte libre en anglais ou en français
+                      (vérifiez toujours si son équivalent existe dans la liste
+                      déroulante afin de diminuer le risque d’écriture multiple
+                      d’un même mot clé -ex: phoque Vs Phoques-).
                     </p>
                     <p>
                       Entrez un mot-clé à la fois. Cliquez sur « Ajouter »
@@ -418,7 +471,8 @@ const IdentificationTab = ({
               dataset hasn't been published.
             </En>
             <Fr>
-              Quelle est la date de première publication des données ? Laissez le champ vide si les données n'ont pas été publiées.
+              Quelle est la date de première publication des données ? Laissez
+              le champ vide si les données n'ont pas été publiées.
             </Fr>
           </I18n>
         </QuestionText>
@@ -438,7 +492,8 @@ const IdentificationTab = ({
               hasn't been revised.
             </En>
             <Fr>
-              Quelle est la date de la dernière révision des données ? Laissez le champ vide si le jeu de données n'a pas été révisé.
+              Quelle est la date de la dernière révision des données ? Laissez
+              le champ vide si le jeu de données n'a pas été révisé.
             </Fr>
           </I18n>
           <SupplementalText>

--- a/src/regions.js
+++ b/src/regions.js
@@ -88,7 +88,7 @@ const regions = {
       en: "Hakai Data Catalogue",
     },
     colors: { primary: "#aa2025", secondary: "#459be2" },
-    email: "info@hakai.org",
+    email: "data@hakai.org",
     catalogueURL: {
       fr: "https://catalogue.hakai.org/",
       en: "https://catalogue.hakai.org/",
@@ -103,7 +103,7 @@ const regions = {
       en: "Test Data Catalogue",
     },
     colors: { primary: "#fcba03", secondary: "#2518ad" },
-    email: "info@hakai.org",
+    email: "data@hakai.org",
     catalogueURL: {
       fr: "https://example.com/",
       en: "https://example.com/",

--- a/src/utils/firebaseRecordFunctions.js
+++ b/src/utils/firebaseRecordFunctions.js
@@ -159,6 +159,14 @@ export function returnRecordToDraft(region, userID, key) {
     .child("status")
     .set("");
 }
+export async function getRegionProjects(region) {
+  const projects = Object.values(
+    (
+      await firebase.database().ref(region).child("projects").once("value")
+    ).toJSON() || {}
+  );
+  return projects;
+}
 
 // runs firebaseToJSObject on each child object
 export const multipleFirebaseToJSObject = (multiple) => {


### PR DESCRIPTION
This PR adds project selection on the Data identification page. Each region can configure their own project list in the Admin page. If the region doesn't list any projects, the question won't be asked. 

This feature is aready implemented in [the metadata-xml repo](https://github.com/cioos-siooc/metadata-xml/)

Fixes #191