### PR TITLE
Update dataset-name.md

### DIFF
--- a/firebase-functions/functions/dataset-name.md
+++ b/firebase-functions/functions/dataset-name.md
@@ -31,6 +31,7 @@
 ### Contact
 
 - [ ] ROR and ORCID(s) are included and linked properly where applicable
+- [ ] For datasets where DFO is a partner, ensure 'parent' ROR is added (https://ror.org/02qa1x782). DFO 'child' organizations (i.e. CHS) and their ROR are optional.
 - [ ] The citation in the metadata record matches the preferred citation mentioned in the data package. 
 - [ ] Include Hakai Institute as Publisher (& Distributor?)
 


### PR DESCRIPTION
As discussed at latest CIOOS Metadata TT meeting, for metadata records where DFO is a responsible organization, parent ROR for DFO has to be used. Adding DFO 'child' organization ROR (i.e. for the CHS, BIO) is optional.