### PR TITLE
Surround firebase-functions-issue generated body url by < >

### DIFF
--- a/firebase-functions/functions/issue.js
+++ b/firebase-functions/functions/issue.js
@@ -20,7 +20,7 @@ async function createIssue(title, url) {
     owner: "HakaiInstitute",
     repo: "metadata-review",
     title: `Dataset - ${title}`,
-    body: `## ${title}\n\n${url}\n\n${issueText}`,
+    body: `## ${title}\n\n<${url}>\n\n${issueText}`,
   };
 
   await octokit.request("POST /repos/{owner}/{repo}/issues", input);


### PR DESCRIPTION
This is related to #245 

The generated issue body fails to provide a working link when a trailing `_` is present.

See https://github.com/HakaiInstitute/metadata-review/issues/66 for an example