### PR TITLE
233 auto translation flag

### DIFF
--- a/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
+++ b/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
@@ -30,6 +30,10 @@ def eovs_to_fr(eovs_en):
     """ Translate a list of EOVs in english to a list in french"""
     return [eov_translations.get(eov,"") for eov in eovs_en if eov]
 
+def verify_translation(verified, message):
+    if not verified:
+        return message
+    return ""
 
 def strip_keywords(keywords):
     """Strips whitespace from each keyword in either language"""

--- a/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
+++ b/firebase_to_xml/firebase_to_xml/record_json_to_yaml.py
@@ -77,6 +77,7 @@ def record_json_to_yaml(record):
             + "https://cioos-siooc.github.io/metadata-entry-form",
             "use_constraints": {
                 "limitations": record.get("limitations", "None"),
+                "limitationsTranslationMethod":  verify_translation(record.get("translationVerifiedLimitations"), record.get("limitationsTranslationMethod")),
                 "licence": licenses.get(
                     record.get(
                         "license",
@@ -107,8 +108,10 @@ def record_json_to_yaml(record):
         },
         "identification": {
             "title": record.get("title"),
+            "titleTranslationMethod":  verify_translation(record.get("translationVerifiedTitle"), record.get("titleTranslationMethod")),
             "identifier": record.get("datasetIdentifier"),
             "abstract": record.get("abstract"),
+            "abstractTranslationMethod":  verify_translation(record.get("translationVerifiedAbstract"), record.get("abstractTranslationMethod")),
             "dates": {
                 "creation": date_from_datetime_str(record.get("dateStart")),
                 "publication": date_from_datetime_str(record.get("datePublished")),
@@ -162,6 +165,7 @@ def record_json_to_yaml(record):
         record_yaml["platform"] = {
             "id": record.get("platformID"),
             "description": record.get("platformDescription"),
+            "platformDescriptionTranslationMethod":  verify_translation(record.get("translationVerifiedPlatformDescription"), record.get("platformDescriptionTranslationMethod")),
             "type": record.get("platform"),
         }
 

--- a/src/components/FormComponents/BilingualTextInput.jsx
+++ b/src/components/FormComponents/BilingualTextInput.jsx
@@ -6,6 +6,8 @@ import {
   CircularProgress,
   Tooltip,
 } from "@material-ui/core";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
 import TranslateIcon from "@material-ui/icons/Translate";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
 import { useParams } from "react-router-dom";
@@ -23,6 +25,8 @@ const BilingualTextInput = ({
   disabled,
   error,
   translationButonDisabled = false,
+  translateChecked,
+  translateOnChange,
 }) => {
   const { translate } = useContext(UserContext);
   const [awaitingTranslation, setAwaitingTranslation] = useState(false);
@@ -109,6 +113,25 @@ const BilingualTextInput = ({
                     <Fr>Traduire</Fr>
                   </I18n>
                 </Button>
+                {translateOnChange && (
+                  <FormControlLabel
+                  control={
+                    <Checkbox
+                      name="platformDescriptionTranslationVerified"
+                      checked={translateChecked}
+                      onChange={translateOnChange}
+                      color="primary"
+                    />
+                  }
+                  label={
+                    <I18n>
+                      <En>I have verified this translation</En>
+                      <Fr>J'ai vérifié cette traduction</Fr>
+                    </I18n>
+                  }
+                />
+                )}
+                
                 {textTooBig && (
                   <I18n>
                     <En>

--- a/src/components/FormComponents/BilingualTextInput.jsx
+++ b/src/components/FormComponents/BilingualTextInput.jsx
@@ -27,6 +27,7 @@ const BilingualTextInput = ({
   translationButonDisabled = false,
   translateChecked,
   translateOnChange,
+  onTranslateComplete,
 }) => {
   const { translate } = useContext(UserContext);
   const [awaitingTranslation, setAwaitingTranslation] = useState(false);
@@ -104,6 +105,7 @@ const BilingualTextInput = ({
                             value: translation,
                           },
                         });
+                        onTranslateComplete(`Auto-translated using AWS`);
                       }
                     );
                   }}

--- a/src/components/FormComponents/BilingualTextInput.jsx
+++ b/src/components/FormComponents/BilingualTextInput.jsx
@@ -119,7 +119,6 @@ const BilingualTextInput = ({
                   <FormControlLabel
                   control={
                     <Checkbox
-                      name="platformDescriptionTranslationVerified"
                       checked={translateChecked}
                       onChange={translateOnChange}
                       color="primary"

--- a/src/components/FormComponents/Platform.jsx
+++ b/src/components/FormComponents/Platform.jsx
@@ -3,6 +3,8 @@ import React from "react";
 import { TextField, Grid, Tooltip } from "@material-ui/core";
 import { useParams } from "react-router-dom";
 import { OpenInNew } from "@material-ui/icons";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
 
 import BilingualTextInput from "./BilingualTextInput";
 import { QuestionText, SupplementalText, paperClass } from "./QuestionStyles";
@@ -12,7 +14,7 @@ import { validateField } from "../../utils/validate";
 import SelectInput from "./SelectInput";
 import platforms from "../../platforms.json";
 
-const Platform = ({ record, handleUpdateRecord, disabled }) => {
+const Platform = ({ record, handleUpdateRecord, disabled, updateRecord }) => {
   const { language = "en" } = useParams();
 
   const platformsSorted = Object.values(platforms).sort((a, b) =>
@@ -139,6 +141,25 @@ const Platform = ({ record, handleUpdateRecord, disabled }) => {
           onChange={handleUpdateRecord("platformDescription")}
           multiline
           disabled={disabled}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              name="platformDescriptionTranslationVerified"
+              checked={record.platformDescriptionTranslationVerified || false}
+              onChange={(e) => {
+                const { checked } = e.target;
+                updateRecord("platformDescriptionTranslationVerified")(checked);
+              }}
+              color="primary"
+            />
+          }
+          label={
+            <I18n>
+              <En>I have verified this translation</En>
+              <Fr>J'ai vérifié cette traduction</Fr>
+            </I18n>
+          }
         />
       </Grid>
     </div>

--- a/src/components/FormComponents/Platform.jsx
+++ b/src/components/FormComponents/Platform.jsx
@@ -12,7 +12,7 @@ import { validateField } from "../../utils/validate";
 import SelectInput from "./SelectInput";
 import platforms from "../../platforms.json";
 
-const Platform = ({ record, handleUpdateRecord, disabled, updateRecord }) => {
+const Platform = ({ record, handleUpdateRecord, handleTranslationComplete, disabled, updateRecord }) => {
   const { language = "en" } = useParams();
 
   const platformsSorted = Object.values(platforms).sort((a, b) =>
@@ -137,6 +137,7 @@ const Platform = ({ record, handleUpdateRecord, disabled, updateRecord }) => {
         <BilingualTextInput
           value={record.platformDescription}
           onChange={handleUpdateRecord("platformDescription")}
+          onTranslateComplete={handleTranslationComplete}
           multiline
           disabled={disabled}
           translateChecked={

--- a/src/components/FormComponents/Platform.jsx
+++ b/src/components/FormComponents/Platform.jsx
@@ -137,7 +137,7 @@ const Platform = ({ record, handleUpdateRecord, handleTranslationComplete, disab
         <BilingualTextInput
           value={record.platformDescription}
           onChange={handleUpdateRecord("platformDescription")}
-          onTranslateComplete={handleTranslationComplete}
+          onTranslateComplete={handleTranslationComplete("platformDescription")}
           multiline
           disabled={disabled}
           translateChecked={

--- a/src/components/FormComponents/Platform.jsx
+++ b/src/components/FormComponents/Platform.jsx
@@ -3,8 +3,6 @@ import React from "react";
 import { TextField, Grid, Tooltip } from "@material-ui/core";
 import { useParams } from "react-router-dom";
 import { OpenInNew } from "@material-ui/icons";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox";
 
 import BilingualTextInput from "./BilingualTextInput";
 import { QuestionText, SupplementalText, paperClass } from "./QuestionStyles";
@@ -141,25 +139,15 @@ const Platform = ({ record, handleUpdateRecord, disabled, updateRecord }) => {
           onChange={handleUpdateRecord("platformDescription")}
           multiline
           disabled={disabled}
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              name="platformDescriptionTranslationVerified"
-              checked={record.platformDescriptionTranslationVerified || false}
-              onChange={(e) => {
-                const { checked } = e.target;
-                updateRecord("platformDescriptionTranslationVerified")(checked);
-              }}
-              color="primary"
-            />
-          }
-          label={
-            <I18n>
-              <En>I have verified this translation</En>
-              <Fr>J'ai vérifié cette traduction</Fr>
-            </I18n>
-          }
+          translateChecked={
+                        record.platformDescriptionTranslationVerified || false
+                      }
+          translateOnChange={(e) => {
+                        const { checked } = e.target;
+                        updateRecord("platformDescriptionTranslationVerified")(
+                          checked
+                        );
+                      }}
         />
       </Grid>
     </div>

--- a/src/components/FormComponents/Platform.jsx
+++ b/src/components/FormComponents/Platform.jsx
@@ -140,11 +140,11 @@ const Platform = ({ record, handleUpdateRecord, disabled, updateRecord }) => {
           multiline
           disabled={disabled}
           translateChecked={
-                        record.platformDescriptionTranslationVerified || false
+                        record.translationVerifiedPlatformDescription || false
                       }
           translateOnChange={(e) => {
                         const { checked } = e.target;
-                        updateRecord("platformDescriptionTranslationVerified")(
+                        updateRecord("translationVerifiedPlatformDescription")(
                           checked
                         );
                       }}

--- a/src/components/Pages/MetadataForm.jsx
+++ b/src/components/Pages/MetadataForm.jsx
@@ -227,6 +227,11 @@ class MetadataForm extends FormClassTemplate {
     }));
   };
 
+  handleTranslationComplete = (fieldName) => (message) => {
+    const translationMethodField = `${fieldName}TranslationMethod`;
+    this.updateRecord(translationMethodField)(message);
+  };
+
   saveUpdateContact(contact) {
     const { contactID } = contact;
     const { match } = this.props;
@@ -374,6 +379,7 @@ class MetadataForm extends FormClassTemplate {
       record,
       handleUpdateRecord: this.handleUpdateRecord,
       updateRecord: this.updateRecord,
+      handleTranslationComplete: this.handleTranslationComplete,
     };
     const percentValidInt = Math.round(percentValid(record) * 100);
     return loading ? (

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -39,6 +39,7 @@ const IdentificationTab = ({
   record,
   handleUpdateRecord,
   updateRecord,
+  handleTranslationComplete,
   projects,
 }) => {
   const { createDraftDoi, updateDraftDoi, deleteDraftDoi } = useContext(UserContext);
@@ -77,11 +78,6 @@ const IdentificationTab = ({
       language
     )
   );
-
-  const handleTranslationComplete = (fieldName) => (message) => {
-    const translationMethodField = `${fieldName}TranslationMethod`;
-    updateRecord(translationMethodField)(message);
-  };
 
   async function handleGenerateDOI() {
     setLoadingDoi(true);

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -255,11 +255,11 @@ const IdentificationTab = ({
         <FormControlLabel
           control={
             <Checkbox
-              name="translationVerified"
-              checked={record.translationVerified || false}
+              name="titleTranslationVerified"
+              checked={record.titleTranslationVerified || false}
               onChange={(e) => {
                 const { checked } = e.target;
-                updateRecord("translationVerified")(checked);
+                updateRecord("titleTranslationVerified")(checked);
               }}
               color="primary"
             />
@@ -415,6 +415,25 @@ const IdentificationTab = ({
           onChange={handleUpdateRecord("abstract")}
           disabled={disabled}
           multiline
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              name="abstractTranslationVerified"
+              checked={record.abstractTranslationVerified || false}
+              onChange={(e) => {
+                const { checked } = e.target;
+                updateRecord("abstractTranslationVerified")(checked);
+              }}
+              color="primary"
+            />
+          }
+          label={
+            <I18n>
+              <En>I have verified this translation</En>
+              <Fr>J'ai vérifié cette traduction</Fr>
+            </I18n>
+          }
         />
       </Paper>
 

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -255,13 +255,21 @@ const IdentificationTab = ({
         <FormControlLabel
           control={
             <Checkbox
-              checked={record.translationVerified || false}
-              onChange={handleUpdateRecord("translationVerified")}
               name="translationVerified"
+              checked={record.translationVerified || false}
+              onChange={(e) => {
+                const { checked } = e.target;
+                updateRecord("translationVerified")(checked);
+              }}
               color="primary"
             />
           }
-          label="I have verified this translation"
+          label={
+            <I18n>
+              <En>I have verified this translation</En>
+              <Fr>J'ai vérifié cette traduction</Fr>
+            </I18n>
+          }
         />
       </Paper>
 
@@ -719,13 +727,12 @@ const IdentificationTab = ({
             <SupplementalText>
               <I18n>
                 <En>
-                  <p>
-                    Please save the form before generating a draft DOI.
-                  </p>
+                  <p>Please save the form before generating a draft DOI.</p>
                 </En>
                 <Fr>
                   <p>
-                  Veuillez enregistrer le formulaire avant de générer un brouillon de DOI.
+                    Veuillez enregistrer le formulaire avant de générer un
+                    brouillon de DOI.
                   </p>
                 </Fr>
               </I18n>
@@ -751,15 +758,12 @@ const IdentificationTab = ({
           </Button>
         )}
         {showUpdateDoi && (
-          <Button
-            onClick={handleUpdateDraftDOI}
-            style={{ display: 'inline' }}
-          >
+          <Button onClick={handleUpdateDraftDOI} style={{ display: "inline" }}>
             <div style={{ display: "flex", alignItems: "center" }}>
               {loadingDoiUpdate ? (
                 <>
-                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                    Loading...
+                  <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                  Loading...
                 </>
               ) : (
                 "Update Draft DOI"
@@ -767,23 +771,20 @@ const IdentificationTab = ({
             </div>
           </Button>
         )}
-      {showDeleteDoi && (
-        <Button
-          onClick={handleDeleteDOI}
-          style={{ display: "inline" }}
-        >
-          <div style={{ display: "flex", alignItems: "center" }}>
-            {loadingDoiDelete ? (
-              <>
+        {showDeleteDoi && (
+          <Button onClick={handleDeleteDOI} style={{ display: "inline" }}>
+            <div style={{ display: "flex", alignItems: "center" }}>
+              {loadingDoiDelete ? (
+                <>
                   <CircularProgress size={24} style={{ marginRight: "8px" }} />
                   Loading...
-              </>
-            ) : (
-              "Delete Draft DOI"
-            )}
-          </div>
-        </Button>
-      )}
+                </>
+              ) : (
+                "Delete Draft DOI"
+              )}
+            </div>
+          </Button>
+        )}
         {doiErrorFlag && (
           <span>
             <I18n
@@ -794,10 +795,7 @@ const IdentificationTab = ({
         )}
         {doiUpdateFlag && (
           <span>
-            <I18n
-              en="DOI has been updated"
-              fr="Le DOI a été mis à jour"
-            />
+            <I18n en="DOI has been updated" fr="Le DOI a été mis à jour" />
           </span>
         )}
 

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -78,6 +78,10 @@ const IdentificationTab = ({
     )
   );
 
+  const handleTranslationComplete = (message) => {
+    updateRecord("translationMethod")(message);
+  };
+
   async function handleGenerateDOI() {
     setLoadingDoi(true);
 
@@ -249,6 +253,7 @@ const IdentificationTab = ({
         <BilingualTextInput
           value={record.title}
           onChange={handleUpdateRecord("title")}
+          onTranslateComplete={handleTranslationComplete}
           disabled={disabled}
           translateChecked={
                         record.translationVerifiedTitle || false
@@ -402,6 +407,7 @@ const IdentificationTab = ({
         <BilingualTextInput
           value={record.abstract}
           onChange={handleUpdateRecord("abstract")}
+          onTranslateComplete={handleTranslationComplete}
           disabled={disabled}
           multiline
           translateChecked={
@@ -962,6 +968,7 @@ const IdentificationTab = ({
         <BilingualTextInput
           value={record.limitations}
           onChange={handleUpdateRecord("limitations")}
+          onTranslateComplete={handleTranslationComplete}
           multiline
           disabled={disabled}
           translateChecked={

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -10,6 +10,8 @@ import {
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { useParams } from "react-router-dom";
 import { OpenInNew, Update } from "@material-ui/icons";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
 import { En, Fr, I18n } from "../I18n";
 import { progressCodes } from "../../isoCodeLists";
 import { eovs, eovCategories } from "../../eovs.json";
@@ -249,6 +251,17 @@ const IdentificationTab = ({
           value={record.title}
           onChange={handleUpdateRecord("title")}
           disabled={disabled}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={record.translationVerified || false}
+              onChange={handleUpdateRecord("translationVerified")}
+              name="translationVerified"
+              color="primary"
+            />
+          }
+          label="I have verified this translation"
         />
       </Paper>
 

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -10,8 +10,6 @@ import {
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { useParams } from "react-router-dom";
 import { OpenInNew, Update } from "@material-ui/icons";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox";
 import { En, Fr, I18n } from "../I18n";
 import { progressCodes } from "../../isoCodeLists";
 import { eovs, eovCategories } from "../../eovs.json";
@@ -251,25 +249,15 @@ const IdentificationTab = ({
           value={record.title}
           onChange={handleUpdateRecord("title")}
           disabled={disabled}
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              name="titleTranslationVerified"
-              checked={record.titleTranslationVerified || false}
-              onChange={(e) => {
-                const { checked } = e.target;
-                updateRecord("titleTranslationVerified")(checked);
-              }}
-              color="primary"
-            />
-          }
-          label={
-            <I18n>
-              <En>I have verified this translation</En>
-              <Fr>J'ai vérifié cette traduction</Fr>
-            </I18n>
-          }
+          translateChecked={
+                        record.titleTranslationVerified || false
+                      }
+          translateOnChange={(e) => {
+                        const { checked } = e.target;
+                        updateRecord("titleTranslationVerified")(
+                          checked
+                        );
+                      }}
         />
       </Paper>
 
@@ -415,25 +403,15 @@ const IdentificationTab = ({
           onChange={handleUpdateRecord("abstract")}
           disabled={disabled}
           multiline
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              name="abstractTranslationVerified"
-              checked={record.abstractTranslationVerified || false}
-              onChange={(e) => {
-                const { checked } = e.target;
-                updateRecord("abstractTranslationVerified")(checked);
-              }}
-              color="primary"
-            />
-          }
-          label={
-            <I18n>
-              <En>I have verified this translation</En>
-              <Fr>J'ai vérifié cette traduction</Fr>
-            </I18n>
-          }
+          translateChecked={
+                        record.abstractTranslationVerified || false
+                      }
+          translateOnChange={(e) => {
+                        const { checked } = e.target;
+                        updateRecord("abstractTranslationVerified")(
+                          checked
+                        );
+                      }}
         />
       </Paper>
 
@@ -985,25 +963,15 @@ const IdentificationTab = ({
           onChange={handleUpdateRecord("limitations")}
           multiline
           disabled={disabled}
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              name="limitationsTranslationVerified"
-              checked={record.limitationsTranslationVerified || false}
-              onChange={(e) => {
-                const { checked } = e.target;
-                updateRecord("limitationsTranslationVerified")(checked);
-              }}
-              color="primary"
-            />
-          }
-          label={
-            <I18n>
-              <En>I have verified this translation</En>
-              <Fr>J'ai vérifié cette traduction</Fr>
-            </I18n>
-          }
+          translateChecked={
+                        record.limitationsTranslationVerified || false
+                      }
+          translateOnChange={(e) => {
+                        const { checked } = e.target;
+                        updateRecord("limitationsTranslationVerified")(
+                          checked
+                        );
+                      }}
         />
       </Paper>
     </div>

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -207,7 +207,6 @@ const IdentificationTab = ({
     }
   }
 
-  console.log(record)
   return (
     <div>
       <Paper style={paperClass}>

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -986,6 +986,25 @@ const IdentificationTab = ({
           multiline
           disabled={disabled}
         />
+        <FormControlLabel
+          control={
+            <Checkbox
+              name="limitationsTranslationVerified"
+              checked={record.limitationsTranslationVerified || false}
+              onChange={(e) => {
+                const { checked } = e.target;
+                updateRecord("limitationsTranslationVerified")(checked);
+              }}
+              color="primary"
+            />
+          }
+          label={
+            <I18n>
+              <En>I have verified this translation</En>
+              <Fr>J'ai vérifié cette traduction</Fr>
+            </I18n>
+          }
+        />
       </Paper>
     </div>
   );

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -206,6 +206,7 @@ const IdentificationTab = ({
     }
   }
 
+  console.log(record)
   return (
     <div>
       <Paper style={paperClass}>
@@ -250,11 +251,11 @@ const IdentificationTab = ({
           onChange={handleUpdateRecord("title")}
           disabled={disabled}
           translateChecked={
-                        record.titleTranslationVerified || false
+                        record.translationVerifiedTitle || false
                       }
           translateOnChange={(e) => {
                         const { checked } = e.target;
-                        updateRecord("titleTranslationVerified")(
+                        updateRecord("translationVerifiedTitle")(
                           checked
                         );
                       }}
@@ -404,11 +405,11 @@ const IdentificationTab = ({
           disabled={disabled}
           multiline
           translateChecked={
-                        record.abstractTranslationVerified || false
+                        record.translationVerifiedAbstract || false
                       }
           translateOnChange={(e) => {
                         const { checked } = e.target;
-                        updateRecord("abstractTranslationVerified")(
+                        updateRecord("translationVerifiedAbstract")(
                           checked
                         );
                       }}
@@ -964,11 +965,11 @@ const IdentificationTab = ({
           multiline
           disabled={disabled}
           translateChecked={
-                        record.limitationsTranslationVerified || false
+                        record.translationVerifiedLimitations || false
                       }
           translateOnChange={(e) => {
                         const { checked } = e.target;
-                        updateRecord("limitationsTranslationVerified")(
+                        updateRecord("translationVerifiedLimitations")(
                           checked
                         );
                       }}

--- a/src/components/Tabs/IdentificationTab.jsx
+++ b/src/components/Tabs/IdentificationTab.jsx
@@ -78,8 +78,9 @@ const IdentificationTab = ({
     )
   );
 
-  const handleTranslationComplete = (message) => {
-    updateRecord("translationMethod")(message);
+  const handleTranslationComplete = (fieldName) => (message) => {
+    const translationMethodField = `${fieldName}TranslationMethod`;
+    updateRecord(translationMethodField)(message);
   };
 
   async function handleGenerateDOI() {
@@ -253,7 +254,7 @@ const IdentificationTab = ({
         <BilingualTextInput
           value={record.title}
           onChange={handleUpdateRecord("title")}
-          onTranslateComplete={handleTranslationComplete}
+          onTranslateComplete={handleTranslationComplete("title")}
           disabled={disabled}
           translateChecked={
                         record.translationVerifiedTitle || false
@@ -407,7 +408,7 @@ const IdentificationTab = ({
         <BilingualTextInput
           value={record.abstract}
           onChange={handleUpdateRecord("abstract")}
-          onTranslateComplete={handleTranslationComplete}
+          onTranslateComplete={handleTranslationComplete("abstract")}
           disabled={disabled}
           multiline
           translateChecked={
@@ -968,7 +969,7 @@ const IdentificationTab = ({
         <BilingualTextInput
           value={record.limitations}
           onChange={handleUpdateRecord("limitations")}
-          onTranslateComplete={handleTranslationComplete}
+          onTranslateComplete={handleTranslationComplete("limitations")}
           multiline
           disabled={disabled}
           translateChecked={

--- a/src/components/Tabs/PlatformTab.jsx
+++ b/src/components/Tabs/PlatformTab.jsx
@@ -87,6 +87,7 @@ const PlatformTab = ({
                 <Platform
                   record={record}
                   handleUpdateRecord={handleUpdateRecord}
+                  updateRecord={updateRecord}
                   disabled={disabled}
                 />
               </>

--- a/src/components/Tabs/PlatformTab.jsx
+++ b/src/components/Tabs/PlatformTab.jsx
@@ -11,6 +11,7 @@ const PlatformTab = ({
   disabled,
   record,
   handleUpdateRecord,
+  handleTranslationComplete,
   updateRecord,
 }) => {
   const noPlatform = record.noPlatform && record.noPlatform !== "false";
@@ -87,6 +88,7 @@ const PlatformTab = ({
                 <Platform
                   record={record}
                   handleUpdateRecord={handleUpdateRecord}
+                  handleTranslationComplete={handleTranslationComplete}
                   updateRecord={updateRecord}
                   disabled={disabled}
                 />


### PR DESCRIPTION

## Description

The primary objective of these changes is to flag unverified translations and provide an auto-translation method message, thereby improving the accuracy of translations across different sections of the application. 

When the user clicks the `TRANSLATE` button, a new field is added to the record object that stores an auto-translation method message for the metadata entry field being translated. A checkbox has been added beside the translate button to indicate whether the user has verified the translation. If the checkbox is checked, the auto-translation method message for the field being translated is not passed on to the yaml file. If the checkbox is not checked, an auto-translation method message for the field is passed on to the yaml file.

This PR solves the problem outlined in https://github.com/cioos-siooc/metadata-entry-form/issues/233

The key features and fixes introduced are summarized as follows:

* added a new `translationVerified` checkbox to the `BilingualTextInput` component. This inclusion allows users to explicitly mark translations as verified in various sections of the metadata entry form, including title, abstract, limitations, and platform description.

* defined the handler function `handleTranslationComplete` to dynamically generate field names that the identify translation method of various metadata fields.

* defined the `verify_translation` python function in `record_json_to_yaml.py` which only returns the auto-translation method message if the translation has not been verified by the user.

* in the `record_json_to_yaml` python function, added the translation method fields for title, abstract, limitations, and platform description, because those are the metadata fields we currently have automatic translation available for. These fields call the above `verify_translation` function for their value.
