### PR TITLE
Fix Discrepancy for publicationYear

### DIFF
--- a/src/components/FormComponents/ApaPreview.jsx
+++ b/src/components/FormComponents/ApaPreview.jsx
@@ -9,6 +9,7 @@ export function generateCitation(record, language, format) {
     created,
     contacts = [],
     datePublished,
+    dateRevised,
   } = record;
 
   const publishers = contacts
@@ -46,7 +47,7 @@ export function generateCitation(record, language, format) {
           // seems that only individuals gets cited? Wasnt sure how to get organization name in there
           return { family: contact.orgName };
         }),
-      issued: { "date-parts": [[datePublished || created]] },
+      issued: { "date-parts": [[dateRevised || datePublished || created]] },
       publisher: publishers.join(", "),
       DOI: datasetIdentifier.replace(/https?:\/\/doi\.org\//, ""),
       version: `v${record.edition}`,

--- a/src/components/FormComponents/DateInput.jsx
+++ b/src/components/FormComponents/DateInput.jsx
@@ -14,11 +14,12 @@ function formatDate(date) {
     const m = date.getMonth();
     const y = date.getFullYear();
     // This is to get around the issue of timezones and dates
-    return new Date(y, m, d, 12, 0, 0, 0);
+    return (new Date(y, m, d, 12, 0, 0, 0)).toISOString();
   } catch (e) {
     return null;
   }
 }
+
 const DateInput = ({ onChange, value, name, disabled, dateStart, dateEnd }) => {
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/src/components/__tests__/DateInput.test.jsx
+++ b/src/components/__tests__/DateInput.test.jsx
@@ -7,7 +7,7 @@ import { KeyboardDatePicker } from "@material-ui/pickers";
 import DateInput from "../FormComponents/DateInput";
 
 // this helps mock the a date
-const mockedData = new Date("2020-11-26T00:00:00.000Z");
+const mockedData = new Date("2020-11-26T00:00:00.000Z").toISOString();
 jest.spyOn(global, "Date").mockImplementation(() => mockedData);
 Date.now = () => 1606348800;
 

--- a/src/components/__tests__/DateInput.test.jsx
+++ b/src/components/__tests__/DateInput.test.jsx
@@ -12,7 +12,7 @@ jest.spyOn(global, "Date").mockImplementation(() => mockedData);
 Date.now = () => 1606348800;
 
 configure({ adapter: new Adapter() });
-const mockEventValue = new Date("2021-09-08T22:23:52.468Z");
+const mockEventValue = new Date("2021-09-08T22:23:52.468Z").toISOString();
 const mockComponentName = "date";
 const mockOnChange = jest.fn();
 

--- a/src/components/__tests__/DateInput.test.jsx
+++ b/src/components/__tests__/DateInput.test.jsx
@@ -7,12 +7,14 @@ import { KeyboardDatePicker } from "@material-ui/pickers";
 import DateInput from "../FormComponents/DateInput";
 
 // this helps mock the a date
-const mockedData = new Date("2020-11-26T00:00:00.000Z").toISOString();
+const mockedData = new Date("2020-11-26T00:00:00.000Z");
 jest.spyOn(global, "Date").mockImplementation(() => mockedData);
 Date.now = () => 1606348800;
 
 configure({ adapter: new Adapter() });
-const mockEventValue = new Date("2021-09-08T22:23:52.468Z").toISOString();
+
+// Use an ISO string for the mock event value
+const mockEventValue = "2021-09-08T22:23:52.468Z"; 
 const mockComponentName = "date";
 const mockOnChange = jest.fn();
 
@@ -33,9 +35,16 @@ describe("<DateInput />", () => {
       />
     );
 
-    wrapper.find(KeyboardDatePicker).props().onChange(mockEventValue);
+    // Simulate selecting a new date as a Date object
+    const newDate = new Date("2021-10-08T22:23:52.468Z");
+    wrapper.find(KeyboardDatePicker).props().onChange(newDate);
+
+    // The expected value should be an ISO string after being processed by your component
+    const expectedValue = newDate.toISOString();
+
+     // Assert that onChange was called with the correct value
     expect(mockOnChange).toHaveBeenCalledWith({
-      target: { value: mockEventValue, name: mockComponentName },
+      target: { value: expectedValue, name: mockComponentName },
     });
   });
 });

--- a/src/utils/recordToDataCite.js
+++ b/src/utils/recordToDataCite.js
@@ -59,11 +59,14 @@ function recordToDataCite(metadata, language, region) {
       contact.role.includes("publisher")
     );
   
-    // Get the publication year from the datePublished field
+    // Get the publication year from the datePublished field, if dateRevised contains value use dateRevised as publication year
     let publicationYear;
-    if (metadata.datePublished) {
-      const year = parseInt(metadata.datePublished.slice(0, 4), 10)
-      publicationYear = Number.isNaN(year) ? undefined : year;
+    if (metadata.dateRevised) {
+      const revisedYear = parseInt(metadata.dateRevised.slice(0, 4), 10);
+      publicationYear = Number.isNaN(revisedYear) ? undefined : revisedYear;
+    } else if (metadata.datePublished) {
+      const publishedYear = parseInt(metadata.datePublished.slice(0, 4), 10)
+      publicationYear = Number.isNaN(publishedYear) ? undefined : publishedYear;
     } else {
       publicationYear = undefined;
     }


### PR DESCRIPTION
This PR fixes the discrepancy outlined in https://github.com/cioos-siooc/metadata-entry-form/issues/295

Updated `recordToDataCite` mapping function to set publicationYear to dateRevised if it exists, otherwise use datePublished.

Updated `generateCitation` function to check for dateRevised before datePublished.