### PR TITLE
Change disabled components to darker grey

### DIFF
--- a/src/components/BaseLayout.jsx
+++ b/src/components/BaseLayout.jsx
@@ -95,10 +95,10 @@ const BaseLayout = ({ match }) => {
         root: {
           '&.Mui-disabled': {
             '& .MuiCheckbox-root': {
-              color: '#6cbd9f', 
+              color: '#ababab', 
             },
             '& .MuiTypography-root': {
-              color: '#6cbd9f',
+              color: '#ababab',
             },
           },
         },
@@ -106,7 +106,7 @@ const BaseLayout = ({ match }) => {
       MuiInputBase: {
         input: {
           '&.Mui-disabled': {
-            color: '#6cbd9f',
+            color: '#ababab',
           },
         },
       },

--- a/src/components/BaseLayout.jsx
+++ b/src/components/BaseLayout.jsx
@@ -91,6 +91,25 @@ const BaseLayout = ({ match }) => {
           fontSize: "1em",
         },
       },
+      MuiFormControlLabel: {
+        root: {
+          '&.Mui-disabled': {
+            '& .MuiCheckbox-root': {
+              color: '#585858', 
+            },
+            '& .MuiTypography-root': {
+              color: '#585858',
+            },
+          },
+        },
+      },
+      MuiInputBase: {
+        input: {
+          '&.Mui-disabled': {
+            color: '#585858',
+          },
+        },
+      },
     },
     palette: {
       primary: {

--- a/src/components/BaseLayout.jsx
+++ b/src/components/BaseLayout.jsx
@@ -95,10 +95,10 @@ const BaseLayout = ({ match }) => {
         root: {
           '&.Mui-disabled': {
             '& .MuiCheckbox-root': {
-              color: '#585858', 
+              color: '#6cbd9f', 
             },
             '& .MuiTypography-root': {
-              color: '#585858',
+              color: '#6cbd9f',
             },
           },
         },
@@ -106,7 +106,7 @@ const BaseLayout = ({ match }) => {
       MuiInputBase: {
         input: {
           '&.Mui-disabled': {
-            color: '#585858',
+            color: '#6cbd9f',
           },
         },
       },


### PR DESCRIPTION
This PR solves issue: https://github.com/cioos-siooc/metadata-entry-form/issues/96

Updated MUI theme to make disabled input text, checkboxes and labels a darker grey, to make the values easier to read.