### PR TITLE
fix contact discrepancy and clarify one contact can occupy multiple roles

### DIFF
--- a/src/components/Tabs/ContactTab.jsx
+++ b/src/components/Tabs/ContactTab.jsx
@@ -96,7 +96,7 @@ const ContactTab = ({
                 Owner for this dataset that can work with{" "}
                 {regions[region].title[language]} Staff to finalize this
                 Metadata Record. You also must select at least one contact to
-                appear in the citation.
+                appear in the citation. One contact can occupy multiple roles.
               </En>
               <Fr>
                 Veuillez saisir au moins un Dépositaire des métadonnées ET un
@@ -104,7 +104,7 @@ const ContactTab = ({
                 être appelées à collaborer avec le personnel
                 {regions[region].titleFrPossessive} pour finaliser la saisie des
                 informations. Vous devez également sélectionner au moins un
-                contact pour apparaître dans la citation.
+                contact pour apparaître dans la citation. Un contact peut occuper plusieurs rôles.
               </Fr>
             </I18n>
             <RequiredMark passes={validateField(record, "contacts")} />

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -197,7 +197,7 @@ const validators = {
       en:
         "Every contact must have at least one role checked, and 'Data Owner' or 'Metadata Custodian' must be added to at least one contact. One contact can occupy multiple roles. Email addresses must be in the form of user@example.com and URLs must be valid.  At least one contact must be selected to appear in the citation.",
       fr:
-        "Chaque contact doit avoir au moins un rôle coché, et « Propriétaire des données » ou « Dépositaire des métadonnées » doit être ajouté à au moins un contact. Les adresses e-mail doivent être au format user@example.com et les URL doivent être valides. Au moins un contact doit être sélectionné pour apparaître dans la citation",
+        "Chaque contact doit avoir au moins un rôle coché, et « Propriétaire des données » ou « Dépositaire des métadonnées » doit être ajouté à au moins un contact. Un contact peut occuper plusieurs rôles. Les adresses e-mail doivent être au format user@example.com et les URL doivent être valides. Au moins un contact doit être sélectionné pour apparaître dans la citation.",
     },
   },
   distribution: {

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -195,9 +195,9 @@ const validators = {
       val.filter(contactIsFilled).find((contact) => contact.inCitation),
     error: {
       en:
-        "Every contact must have at least one role checked, and  'Data contact' or 'Metadata contact' must be added to at least one contact. Email addresses must be in the form of user@example.com and URLs must be valid.  At least one contact must be selected to appear in the citation.",
+        "Every contact must have at least one role checked, and 'Data Owner' or 'Metadata Custodian' must be added to at least one contact. One contact can occupy multiple roles. Email addresses must be in the form of user@example.com and URLs must be valid.  At least one contact must be selected to appear in the citation.",
       fr:
-        "Assurez-vous que chaque contact a un rôle qui lui est attribué. Assurez-vous également d'avoir une personne ressource pour les métadonnées et un personne ressource pour les données. Les adresses e-mail doivent être sous la forme de user@example.com et les URL doivent être valides. Au moins un contact doit être sélectionné pour apparaître dans la citation",
+        "Chaque contact doit avoir au moins un rôle coché, et « Propriétaire des données » ou « Dépositaire des métadonnées » doit être ajouté à au moins un contact. Les adresses e-mail doivent être au format user@example.com et les URL doivent être valides. Au moins un contact doit être sélectionné pour apparaître dans la citation",
     },
   },
   distribution: {


### PR DESCRIPTION
### Description
These changes address the inconsistent text/labels noted in issue: https://github.com/cioos-siooc/metadata-entry-form/issues/249

### Changes:
On submit tab changed "Data Contact" and "Metadata Contact" to "Data Owner" and "Metadata Custodian" to match the text in Contact Tab.

Added "One contact can occupy multiple roles" on Contact tab, and in Contact Error warning on Submit Tab.