### PR TITLE
select resource type on start page

### DIFF
--- a/src/components/Tabs/StartTab.jsx
+++ b/src/components/Tabs/StartTab.jsx
@@ -1,14 +1,22 @@
 import React from "react";
 
 import { Save } from "@material-ui/icons";
-import { Typography, Paper, Grid } from "@material-ui/core";
+import {
+  Typography,
+  Paper,
+  Grid,
+  FormControl,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+} from "@material-ui/core";
 import { useParams } from "react-router-dom";
 
 import regions from "../../regions";
 
 import { En, Fr, I18n } from "../I18n";
 import RequiredMark from "../FormComponents/RequiredMark";
-import { paperClass } from "../FormComponents/QuestionStyles";
+import { paperClass, QuestionText } from "../FormComponents/QuestionStyles";
 
 const StartTab = ({ disabled }) => {
   const { region } = useParams();
@@ -124,6 +132,36 @@ const StartTab = ({ disabled }) => {
             </I18n>
           </li>
         </ul>
+      </Paper>
+      <Paper style={paperClass}>
+        {/* Radio Buttons here for Resource Type selection */}
+        <FormControl>
+          <QuestionText style={{ paddingBottom: "15px" }}>
+            <I18n>
+              <En>What is the resource type of the dataset?</En>
+              <Fr>Quel est le type de ressource de l'ensemble de données?</Fr>
+            </I18n>
+            {/* TO DO: ADD VALIDATION FOR RESOURCE TYPE BEING SELECTED */}
+            <RequiredMark  />
+          </QuestionText>
+          <RadioGroup
+            aria-labelledby="resource-type"
+            defaultValue=""
+            name="resource-type"
+          >
+            <FormControlLabel
+              value="oceanographic"
+              control={<Radio />}
+              label="Oceanographic"
+            />
+            <FormControlLabel
+              value="biological"
+              control={<Radio />}
+              label="Biological"
+            />
+            <FormControlLabel value="model" control={<Radio />} label="Model" />
+          </RadioGroup>
+        </FormControl>
       </Paper>
     </Grid>
   );

--- a/src/components/Tabs/StartTab.jsx
+++ b/src/components/Tabs/StartTab.jsx
@@ -134,15 +134,13 @@ const StartTab = ({ disabled, handleUpdateRecord }) => {
         </ul>
       </Paper>
       <Paper style={paperClass}>
-        {/* Radio Buttons here for Resource Type selection */}
-        {/* TO DO: ADD STATE UPDATE FOR SELECTION */}
         <FormControl>
           <QuestionText style={{ paddingBottom: "15px" }}>
             <I18n>
               <En>What is the resource type of the dataset?</En>
               <Fr>Quel est le type de ressource de l'ensemble de données?</Fr>
             </I18n>
-            {/* TO DO: ADD VALIDATION FOR RESOURCE TYPE BEING SELECTED */}
+            {/* TO DO: ADD VALIDATION TO ENSURE A RESOURCE TYPE IS SELECTED */}
             <RequiredMark  />
           </QuestionText>
           <RadioGroup

--- a/src/components/Tabs/StartTab.jsx
+++ b/src/components/Tabs/StartTab.jsx
@@ -18,7 +18,7 @@ import { En, Fr, I18n } from "../I18n";
 import RequiredMark from "../FormComponents/RequiredMark";
 import { paperClass, QuestionText } from "../FormComponents/QuestionStyles";
 
-const StartTab = ({ disabled }) => {
+const StartTab = ({ disabled, handleUpdateRecord }) => {
   const { region } = useParams();
   const regionInfo = regions[region];
 
@@ -135,6 +135,7 @@ const StartTab = ({ disabled }) => {
       </Paper>
       <Paper style={paperClass}>
         {/* Radio Buttons here for Resource Type selection */}
+        {/* TO DO: ADD STATE UPDATE FOR SELECTION */}
         <FormControl>
           <QuestionText style={{ paddingBottom: "15px" }}>
             <I18n>
@@ -148,6 +149,7 @@ const StartTab = ({ disabled }) => {
             aria-labelledby="resource-type"
             defaultValue=""
             name="resource-type"
+            onChange={handleUpdateRecord("resourceType")}
           >
             <FormControlLabel
               value="oceanographic"
@@ -159,7 +161,11 @@ const StartTab = ({ disabled }) => {
               control={<Radio />}
               label="Biological"
             />
-            <FormControlLabel value="model" control={<Radio />} label="Model" />
+            <FormControlLabel 
+              value="model"  
+              control={<Radio />} 
+              label="Model" 
+            />
           </RadioGroup>
         </FormControl>
       </Paper>


### PR DESCRIPTION
This PR solves issue https://github.com/cioos-siooc/metadata-entry-form/issues/264

So far all that's been done is the addition of radio buttons on the start page allowing users to select 'Resource Type' from three options, 'Oceanographic', 'Biological', 'Model'. The selection updates the `record` object with the field `resourceType`.