### PR TITLE
use previous firebase deploy action version

### DIFF
--- a/.github/workflows/firebase-deploy.yaml
+++ b/.github/workflows/firebase-deploy.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "GITHUB_AUTH=${{ secrets.ISSUE_CREATOR_PAT }}" >> .env
         working-directory: firebase-functions/functions
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v13.2.1
         with:
           args: deploy --only functions
         env:


### PR DESCRIPTION
The following workflow failed:
- name: Deploy to Firebase
        uses: w9jds/firebase-action@master

v13.4.1 was released 17 hours ago so likely there is a bug

using v13.2.1 for now. 