### PR TITLE
fix queries in notifyReviewer and notifyUser to access permissions

### DIFF
--- a/firebase-functions/functions/notify.js
+++ b/firebase-functions/functions/notify.js
@@ -29,7 +29,7 @@ exports.notifyReviewer = functions.database
     // Don't notify if going from published to submitted
     if (after.val() === "submitted" && !before.val()) {
       const reviewersFirebase = await db
-        .ref(`/${region}/permissions/reviewers`)
+        .ref(`/admin/${region}/permissions/reviewers`)
         .once("value");
 
       const reviewers = reviewersFirebase.val().split(",");
@@ -97,7 +97,7 @@ exports.notifyUser = functions.database
     const { region, userID, recordID } = context.params;
     if (after.val() === "published") {
       const reviewersFirebase = await db
-        .ref(`/${region}/permissions/reviewers`)
+        .ref(`/admin/${region}/permissions/reviewers`)
         .once("value");
 
       const reviewers = reviewersFirebase.val().split(",");


### PR DESCRIPTION
This PR addresses https://github.com/cioos-siooc/metadata-entry-form/issues/332

Changes:

The database structure was recently updated to store permissions under an `admin` node. 
To fix the bug in the mentioned issue, database queries in the firebase functions needed to be updated to reflect the recent changes to the database structure.
