### PR TITLE
Fix loggedIn state not set for non-admin users

### DIFF
--- a/firebase-functions/database.rules.json
+++ b/firebase-functions/database.rules.json
@@ -25,11 +25,11 @@
                   ".read": "auth.uid != null"
                   },
               "permissions": {
+                // Allow read access to any authenticated user.
+                ".read": "auth.uid != null",
                   "admins": {
                   // Allow write access for admins if the authenticated user's email is listed as an admin in the permissions for the region.
                   ".write": "root.child('admin').child($regionAdmin).child('permissions').child('admins').val().contains(auth.email)",
-                  // Allow read access to any authenticated user.
-                  ".read": "auth.uid != null",
                   },
                   "reviewers": {
                   // Allow write access for reviewers if the authenticated user's email is listed as an admin in the permissions for the region.

--- a/src/providers/UserProvider.jsx
+++ b/src/providers/UserProvider.jsx
@@ -28,6 +28,7 @@ class UserProvider extends FormClassTemplate {
     this.unsubscribe = auth.onAuthStateChanged((userAuth) => {
       if (userAuth) {
         const { displayName, email, uid } = userAuth;
+        this.setState({ user: userAuth, authIsLoading: false, loggedIn: true });
 
         Sentry.configureScope((scope) => {
           scope.setUser({
@@ -64,7 +65,6 @@ class UserProvider extends FormClassTemplate {
             reviewers,
             isAdmin,
             isReviewer,
-            loggedIn: true,
           });
         });
         this.listenerRefs.push(permissionsRef);


### PR DESCRIPTION
This PR fixes the bug noted in https://github.com/cioos-siooc/metadata-entry-form/issues/331

Due to the recent restructure of admin/permissions in the database, the `loggedIn` state was not being updated for non-admin users.

The fix sets the `loggedIn` state for authenticated users before checking further permissions.

Also needed to fix Firebase rules to allow read on permissions for all authenticated users.