### PR TITLE
Fix Failing Firebase Deploy Action

### DIFF
--- a/.github/workflows/firebase-deploy.yaml
+++ b/.github/workflows/firebase-deploy.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
         working-directory: firebase-functions
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
       - name: Install Dependencies
         run: npm ci
         working-directory: firebase-functions/functions

--- a/.github/workflows/firebase-deploy.yaml
+++ b/.github/workflows/firebase-deploy.yaml
@@ -22,8 +22,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
         working-directory: firebase-functions/functions
-      - name: Create .env file
+      - name: Authenticate Firebase and Deploy
         run: |
+          echo "Creating .env file..."
           echo "GMAIL_USER=${{ secrets.GMAIL_USER }}" >> .env
           echo "GMAIL_PASS=${{ secrets.GMAIL_PASS }}" >> .env
           echo "DATACITE_AUTH_HASH=${{ secrets.DATACITE_AUTH_HASH }}" >> .env
@@ -33,16 +34,11 @@ jobs:
           echo "GITHUB_AUTH=${{ secrets.ISSUE_CREATOR_PAT }}" >> .env
           echo "REACT_APP_GOOGLE_CLOUD_API_KEY=${{ secrets.REACT_APP_GOOGLE_CLOUD_API_KEY }}" >> .env
           echo "REACT_APP_GOOGLE_CLOUD_API_KEY_DEV=${{ secrets.REACT_APP_GOOGLE_CLOUD_API_KEY_DEV }}" >> .env
+          echo "Setting Firebase Project..."
+          firebase use default
+          echo "Deploying to Firebase..."
+          firebase deploy --only functions --token ${{ secrets.FIREBASE_TOKEN }}
         working-directory: firebase-functions/functions
-
-      - name: Set Firebase Project
-        run: firebase use default
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-      - name: Deploy to Firebase
-        uses: w9jds/firebase-action@v13.2.1
-        with:
-          args: deploy --only functions
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           GMAIL_USER: ${{ secrets.GMAIL_USER }}

--- a/.github/workflows/firebase-deploy.yaml
+++ b/.github/workflows/firebase-deploy.yaml
@@ -32,10 +32,14 @@ jobs:
           echo "REACT_APP_GOOGLE_CLOUD_API_KEY=${{ secrets.REACT_APP_GOOGLE_CLOUD_API_KEY }}" >> .env
           echo "REACT_APP_GOOGLE_CLOUD_API_KEY_DEV=${{ secrets.REACT_APP_GOOGLE_CLOUD_API_KEY_DEV }}" >> .env
         working-directory: firebase-functions/functions
+
+      - name: Set Firebase Project
+        run: firebase use default  # Use the alias for your project
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@v13.2.1
         with:
-          projectId: cioos-metadata-form
           args: deploy --only functions
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/firebase-deploy.yaml
+++ b/.github/workflows/firebase-deploy.yaml
@@ -34,7 +34,7 @@ jobs:
         working-directory: firebase-functions/functions
 
       - name: Set Firebase Project
-        run: firebase use default  # Use the alias for your project
+        run: firebase use default
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
       - name: Deploy to Firebase


### PR DESCRIPTION
Tell firebase to use default project in the workflow file. 

All Firebase-related commands are run in a single step to ensure context persistence.