### PR TITLE
336 ROR search field doesn't always populate ROR URL

### DIFF
--- a/src/components/FormComponents/ContactEditor.jsx
+++ b/src/components/FormComponents/ContactEditor.jsx
@@ -67,9 +67,15 @@ const ContactEditor = ({
     ) {
        if (mounted.current) setRorSearchActive(false);
     } else {
-      fetch(`https://api.ror.org/organizations?query=${newInputValue}`)
+      fetch(`https://api.ror.org/organizations?query="${newInputValue}"`)
         .then((response) => response.json())
-        .then((response) => {if (mounted.current) setRorOptions(response.items)})
+        .then((response) => {
+          if (mounted.current){
+            setRorOptions(response.items)}
+          if (response.number_of_results === 1){
+            updateContactRor(response.items[0]);
+          }
+        })
         .then(() => {if (mounted.current) setRorSearchActive(false)});
     }
   }


### PR DESCRIPTION
fix https://github.com/cioos-siooc/metadata-entry-form/issues/336
populate ror immedeitly if only one result is returned. use exact matching qhen searching for organizations so that spaces are handled correclty