### PR TITLE
Fix/polygon precision

### DIFF
--- a/src/components/FormComponents/MapSelect.jsx
+++ b/src/components/FormComponents/MapSelect.jsx
@@ -96,7 +96,7 @@ const MapSelect = ({ updateMap, mapData = {}, disabled, record }) => {
   }
 
   function limitDecimals(x) {
-    return Number.parseFloat(x).toPrecision(4);
+    return Number(Number.parseFloat(x).toFixed(4));
   }
 
   // update the polygon property using an event


### PR DESCRIPTION
Fix polygon precision to keep a fix number of decimals. We selected for now 4 decimals which is minimum 10m accuracy.

