### PR TITLE
Updated attributes for Atlantic region

### DIFF
--- a/src/regions.js
+++ b/src/regions.js
@@ -64,6 +64,10 @@ const regions = {
       fr: "Catalogue de données du SIOOC du Atlantic",
       en: "CIOOS Atlantic Data Catalogue",
     },
+    catalogueTitleMinuscule: {
+      fr: "Catalogue de données du SIOOC du Atlantic",
+      en: "CIOOS Atlantic Data Catalogue",
+    },
     colors: { primary: "#19222b", secondary: "#e55162" },
     email: "info@cioosatlantic.ca",
     catalogueURL: {


### PR DESCRIPTION
There seems to be a recent issue with the Atlantic Metadata Entry form where metadata records won't submit without throwing an error

<img width="1034" height="554" alt="image" src="https://github.com/user-attachments/assets/206aa97c-903c-424d-9168-52c5cf00daad" />

From the console it looks like it's hitting an undefined object in the submit text (regionInfo.catalogueTitleMinuscule.fr). In the regions information (https://github.com/cioos-siooc/metadata-entry-form/blob/main/src/regions.js) Atlantic didn't have that field set to anything. This is just a quick fix adding that information into the file (no change from the original catalogueTitle)