### PR TITLE
Add Plausible analytics tracking to form.cioos.ca

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="CIOOS Metadata intake form" />
+  <script defer data-domain="form.cioos.ca" src="https://plausible.cioos.ca/js/script.file-downloads.hash.outbound-links.js"></script>
+  <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
Integrated Plausible analytics tracking to monitor site usage on form.cioos.ca by adding script tags to public/index.html. Analytics will only track on the production domain form.cioos.ca, not local domains. To test I modified my local hosts file to point form.cioos.ca to my loop back 127.0.0.1 and verified analytics updates on the plausible interface.  