### PR TITLE
Avoid uploading form metadata to Datacite when form is in draft and tooltip to reflect that

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx vitest:*)"
+    ]
+  }
+}

--- a/firebase-functions/functions/datacite.js
+++ b/firebase-functions/functions/datacite.js
@@ -241,6 +241,79 @@ exports.getDoiStatus = functions.https.onCall(async (data) => {
 
 });
 
+// Test stored DataCite credentials by attempting to create and immediately delete a draft DOI.
+// This validates that the credentials and prefix are correct and have write access.
+// Returns { success: true } if the credentials are valid, or throws an HttpsError on failure.
+exports.testDataciteCredentials = functions.https.onCall(async (region) => {
+  let authHash;
+  let prefix;
+
+  try {
+    const credentialsRef = admin.database().ref('admin').child(region).child("dataciteCredentials");
+    authHash = (await credentialsRef.child("dataciteHash").once("value")).val();
+    prefix = (await credentialsRef.child("prefix").once("value")).val();
+  } catch (error) {
+    functions.logger.error(`[testDataciteCredentials] Error fetching credentials for region ${region}:`, error);
+    throw new functions.https.HttpsError('internal', 'Failed to read stored credentials from database.');
+  }
+
+  if (!authHash || !prefix) {
+    throw new functions.https.HttpsError('failed-precondition', 'No DataCite credentials are stored. Please save credentials first.');
+  }
+
+  const baseUrl = await getBaseUrl(region);
+  let testDoi;
+
+  // Step 1: Create a minimal draft DOI to verify credentials and prefix
+  try {
+    const createPayload = {
+      data: {
+        type: "dois",
+        attributes: {
+          prefix,
+        },
+      },
+    };
+
+    const createResponse = await axios.post(baseUrl, createPayload, {
+      headers: {
+        'Authorization': `Basic ${authHash}`,
+        'Content-Type': 'application/vnd.api+json',
+      },
+    });
+
+    testDoi = createResponse.data?.data?.id;
+    functions.logger.info(`[testDataciteCredentials] Draft DOI created: ${testDoi}`);
+  } catch (err) {
+    functions.logger.error("[testDataciteCredentials] Create failed:", { status: err.response?.status, data: err.response?.data });
+    if (err.response && err.response.status === 401) {
+      throw new functions.https.HttpsError('unauthenticated', 'Unauthorized: The stored credentials are invalid. Please update them.');
+    }
+    if (err.response && err.response.status === 403) {
+      throw new functions.https.HttpsError('permission-denied', 'Forbidden: The account does not have permission to create DOIs. Please check your credentials and prefix.');
+    }
+    const errMessage = err.response
+      ? `DataCite API returned ${err.response.status}: ${err.response.statusText}`
+      : err.message || 'Unknown error connecting to DataCite API.';
+    throw new functions.https.HttpsError('unknown', errMessage);
+  }
+
+  // Step 2: Clean up by deleting the test draft DOI
+  if (testDoi) {
+    try {
+      await axios.delete(`${baseUrl}${testDoi}`, {
+        headers: { 'Authorization': `Basic ${authHash}` },
+      });
+      functions.logger.info(`[testDataciteCredentials] Test DOI ${testDoi} deleted.`);
+    } catch (deleteErr) {
+      functions.logger.warn(`[testDataciteCredentials] Failed to delete test DOI ${testDoi}:`, deleteErr.message);
+      // Don't fail the test — credentials are valid, cleanup is best-effort
+    }
+  }
+
+  return { success: true, message: 'Credentials verified successfully. A test DOI was created and removed.' };
+});
+
 // helper function to get the datacite credentials from the database so they are not sent to the client
 exports.getCredentialsStored = functions.https.onCall(async (data) => {
   try {

--- a/firebase-functions/functions/index.js
+++ b/firebase-functions/functions/index.js
@@ -1,7 +1,7 @@
 const admin = require("firebase-admin");
 const { translate } = require("./translate");
 const { checkURLActive } = require("./serverUtils");
-const { createDraftDoi, updateDraftDoi, deleteDraftDoi, getDoiStatus, getCredentialsStored, getDatacitePrefix } = require("./datacite");
+const { createDraftDoi, updateDraftDoi, deleteDraftDoi, getDoiStatus, getCredentialsStored, getDatacitePrefix, testDataciteCredentials } = require("./datacite");
 const { notifyReviewer, notifyUser } = require("./notify");
 const {
   updatesRecordCreate,
@@ -29,4 +29,5 @@ exports.getDoiStatus = getDoiStatus;
 exports.checkURLActive = checkURLActive;
 exports.getCredentialsStored = getCredentialsStored;
 exports.getDatacitePrefix = getDatacitePrefix;
+exports.testDataciteCredentials = testDataciteCredentials;
 exports.githubPublishRecord = githubPublishRecord;

--- a/src/components/FormComponents/DOIInput.jsx
+++ b/src/components/FormComponents/DOIInput.jsx
@@ -256,146 +256,85 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
             </QuestionText>
             {
                 showGenerateDoi && (
-                    <I18n>
-                        <En>
-                            <Tooltip
-                                title={
+                    <Tooltip
+                        title={
+                            <I18n>
+                                <En>
                                     <ol style={{ margin: 0, paddingLeft: "1.2em", fontSize: "0.85rem" }}>
                                         <li><strong>Generate DOI</strong> reserves a draft DOI with DataCite (no metadata is sent yet).</li>
                                         <li>Once the record status is <strong>submitted</strong> or <strong>published</strong>, generating a DOI will automatically include the full metadata.</li>
                                         <li><strong>Update DOI</strong> pushes the latest metadata to DataCite. This button is only enabled when the record is submitted or published.</li>
                                         <li><strong>Delete DOI</strong> removes a draft DOI from DataCite (only available while the DOI is in draft status).</li>
                                     </ol>
-                                }
-                                arrow
-                                placement="top"
-                            >
-                                <div style={{ display: "inline" }}>
-                                    <Button
-                                        onClick={() => handleGenerateDOI()}
-                                        disabled={generateDoiDisabled}
-                                        style={{ display: "inline", marginRight: "15px" }}
-                                    >
-                                        <div style={{ display: "flex", alignItems: "center" }}>
-                                            {loadingDoi ? (
-                                                <>
-                                                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                                    Loading...
-                                                </>
-                                            ) : (
-                                                "Generate DOI"
-                                            )}
-                                        </div>
-                                    </Button>
-                                    {showUpdateDoi && (
-                                        <Button
-                                            onClick={() => handleUpdateDraftDOI()}
-                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status) || loadingDoi || loadingDoiUpdate}
-                                            style={{ display: 'inline', marginRight: "15px" }}
-                                        >
-                                            <div style={{ display: "flex", alignItems: "center" }}>
-                                                {loadingDoiUpdate ? (
-                                                    <>
-                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                                        Loading...
-                                                    </>
-                                                ) : (
-                                                    "Update DOI"
-                                                )}
-                                            </div>
-                                        </Button>
-                                    )}
-                                    {showDeleteDoi && (
-                                        <Button
-                                            onClick={() => handleDeleteDOI()}
-                                            disabled={record.doiCreationStatus !== 'draft' || loadingDoiDelete || loadingDoi}
-                                            style={{ display: "inline", marginRight: "15px" }}
-                                        >
-                                            <div style={{ display: "flex", alignItems: "center" }}>
-                                                {loadingDoiDelete ? (
-                                                    <>
-                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                                        Loading...
-                                                    </>
-                                                ) : (
-                                                    "Delete DOI"
-                                                )}
-                                            </div>
-                                        </Button>
-                                    )}
-                                </div>
-                            </Tooltip>
-                        </En>
-                        <Fr>
-                            <Tooltip
-                                title={
+                                </En>
+                                <Fr>
                                     <ol style={{ margin: 0, paddingLeft: "1.2em", fontSize: "0.85rem" }}>
                                         <li><strong>Générer un DOI</strong> réserve un DOI brouillon auprès de DataCite (aucune métadonnée n&apos;est envoyée).</li>
                                         <li>Lorsque le statut est <strong>soumis</strong> ou <strong>publié</strong>, la génération inclura automatiquement les métadonnées complètes.</li>
                                         <li><strong>Mettre à jour le DOI</strong> envoie les métadonnées les plus récentes à DataCite. Activé uniquement lorsque soumis ou publié.</li>
                                         <li><strong>Supprimer le DOI</strong> supprime un DOI brouillon de DataCite (disponible uniquement en statut brouillon).</li>
                                     </ol>
-                                }
-                                arrow
-                                placement="top"
+                                </Fr>
+                            </I18n>
+                        }
+                        arrow
+                        placement="top"
+                    >
+                        <div style={{ display: "inline" }}>
+                            <Button
+                                onClick={() => handleGenerateDOI()}
+                                disabled={generateDoiDisabled}
+                                style={{ display: "inline", marginRight: "15px" }}
                             >
-                                <div style={{ display: "inline" }}>
-                                    <Button
-                                        onClick={() => handleGenerateDOI()}
-                                        disabled={generateDoiDisabled}
-                                        style={{ display: "inline", marginRight: "15px" }}
-                                    >
-                                        <div style={{ display: "flex", alignItems: "center" }}>
-                                            {loadingDoi ? (
-                                                <>
-                                                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                                    Loading...
-                                                </>
-                                            ) : (
-                                                "Generate DOI"
-                                            )}
-                                        </div>
-                                    </Button>
-                                    {showUpdateDoi && (
-                                        <Button
-                                            onClick={() => handleUpdateDraftDOI()}
-                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status) || loadingDoi || loadingDoiUpdate}
-                                            style={{ display: 'inline', marginRight: "15px" }}
-                                        >
-                                            <div style={{ display: "flex", alignItems: "center" }}>
-                                                {loadingDoiUpdate ? (
-                                                    <>
-                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                                        Loading...
-                                                    </>
-                                                ) : (
-                                                    "Update DOI"
-                                                )}
-                                            </div>
-                                        </Button>
-                                    )}
-                                    {showDeleteDoi && (
-                                        <Button
-                                            onClick={() => handleDeleteDOI()}
-                                            disabled={record.doiCreationStatus !== 'draft' || loadingDoiDelete || loadingDoi}
-                                            style={{ display: "inline", marginRight: "15px" }}
-                                        >
-                                            <div style={{ display: "flex", alignItems: "center" }}>
-                                                {loadingDoiDelete ? (
-                                                    <>
-                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                                        Loading...
-                                                    </>
-                                                ) : (
-                                                    "Delete DOI"
-                                                )}
-                                            </div>
-                                        </Button>
+                                <div style={{ display: "flex", alignItems: "center" }}>
+                                    {loadingDoi ? (
+                                        <>
+                                            <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                            <I18n en="Loading..." fr="Chargement..." />
+                                        </>
+                                    ) : (
+                                        <I18n en="Generate DOI" fr="Générer un DOI" />
                                     )}
                                 </div>
-                            </Tooltip>
-                        </Fr>
-                    </I18n>
+                            </Button>
+                            {showUpdateDoi && (
+                                <Button
+                                    onClick={() => handleUpdateDraftDOI()}
+                                    disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status) || loadingDoi || loadingDoiUpdate}
+                                    style={{ display: 'inline', marginRight: "15px" }}
+                                >
+                                    <div style={{ display: "flex", alignItems: "center" }}>
+                                        {loadingDoiUpdate ? (
+                                            <>
+                                                <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                <I18n en="Loading..." fr="Chargement..." />
+                                            </>
+                                        ) : (
+                                            <I18n en="Update DOI" fr="Mettre à jour le DOI" />
+                                        )}
+                                    </div>
+                                </Button>
+                            )}
+                            {showDeleteDoi && (
+                                <Button
+                                    onClick={() => handleDeleteDOI()}
+                                    disabled={record.doiCreationStatus !== 'draft' || loadingDoiDelete || loadingDoi}
+                                    style={{ display: "inline", marginRight: "15px" }}
+                                >
+                                    <div style={{ display: "flex", alignItems: "center" }}>
+                                        {loadingDoiDelete ? (
+                                            <>
+                                                <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                <I18n en="Loading..." fr="Chargement..." />
+                                            </>
+                                        ) : (
+                                            <I18n en="Delete DOI" fr="Supprimer le DOI" />
+                                        )}
+                                    </div>
+                                </Button>
+                            )}
+                        </div>
+                    </Tooltip>
                 )
             }
 

--- a/src/components/FormComponents/DOIInput.jsx
+++ b/src/components/FormComponents/DOIInput.jsx
@@ -4,6 +4,7 @@ import {
     Paper,
     TextField,
     Button,
+    Tooltip,
 } from "@mui/material";
 import CircularProgress from "@mui/material/CircularProgress";
 import Alert from "@mui/material/Alert";
@@ -15,7 +16,6 @@ import { getDatabase, ref, child, update } from "firebase/database";
 import { En, Fr, I18n } from "../I18n";
 
 import firebase from "../../firebase";
-import { recordToDataCiteFromPython } from "../../utils/recordToDataCiteFromPython";
 import { validateDOI } from "../../utils/validate";
 
 import {
@@ -57,12 +57,21 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
         console.log("[DOIInput] handleGenerateDOI", { region, datacitePrefix, language, identifier: record.identifier, recordID: record.recordID });
 
         try {
-            const mappedDataCiteObject = await recordToDataCiteFromPython(record, language, region, datacitePrefix, { forUpdate: false });
+            // Create a minimal draft DOI with just the prefix.
+            // Full metadata will be pushed when the record is submitted or published.
+            const minimalPayload = {
+                data: {
+                    type: "dois",
+                    attributes: {
+                        prefix: datacitePrefix,
+                    },
+                },
+            };
 
-            console.log("[DOIInput] createDraftDoi payload", { region, mappedDataCiteObject });
+            console.log("[DOIInput] createDraftDoi payload", { region, minimalPayload });
 
             await createDraftDoi({
-                record: mappedDataCiteObject,
+                record: minimalPayload,
                 region,
             })
                 .then((response) => {
@@ -89,6 +98,17 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
                     }
 
                     setDoiGenerated(true);
+
+                    // If the record is already submitted or published, push full metadata immediately
+                    if (["submitted", "published"].includes(record.status)) {
+                        try {
+                            await performUpdateDraftDoi(updatedRecord, region, language, datacitePrefix);
+                        } catch (updateErr) {
+                            console.error("[DOIInput] auto-update after generate failed", updateErr);
+                            setDoiErrorFlag(true);
+                            setDoiErrorMessage(updateErr.message || "DOI created but failed to push metadata. Try clicking Update DOI.");
+                        }
+                    }
                 })
                 .finally(() => {
                     setLoadingDoi(false);
@@ -236,62 +256,146 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
             </QuestionText>
             {
                 showGenerateDoi && (
-                    <Button
-                        onClick={() => handleGenerateDOI()}
-                        disabled={generateDoiDisabled}
-                        style={{ display: "inline", marginRight: "15px" }}
-                    >
-                        <div style={{ display: "flex", alignItems: "center" }}>
-                            {loadingDoi ? (
-                                <>
-                                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                    Loading...
-                                </>
-                            ) : (
-                                "Generate DOI"
-                            )}
-                        </div>
-                    </Button>
-                )
-            }
-            {
-                showUpdateDoi && (
-                    <Button
-                        onClick={() => handleUpdateDraftDOI()}
-                        disabled={['not found', 'unknown'].includes(record.doiCreationStatus)}
-                        style={{ display: 'inline', marginRight: "15px" }}
-                    >
-                        <div style={{ display: "flex", alignItems: "center" }}>
-                            {loadingDoiUpdate ? (
-                                <>
-                                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                    Loading...
-                                </>
-                            ) : (
-                                "Update DOI"
-                            )}
-                        </div>
-                    </Button>
-                )
-            }
-            {
-                showDeleteDoi && (
-                    <Button
-                        onClick={() => handleDeleteDOI()}
-                        disabled={record.doiCreationStatus !== 'draft'}
-                        style={{ display: "inline", marginRight: "15px" }}
-                    >
-                        <div style={{ display: "flex", alignItems: "center" }}>
-                            {loadingDoiDelete ? (
-                                <>
-                                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
-                                    Loading...
-                                </>
-                            ) : (
-                                "Delete DOI"
-                            )}
-                        </div>
-                    </Button>
+                    <I18n>
+                        <En>
+                            <Tooltip
+                                title={
+                                    <ol style={{ margin: 0, paddingLeft: "1.2em", fontSize: "0.85rem" }}>
+                                        <li><strong>Generate DOI</strong> reserves a draft DOI with DataCite (no metadata is sent yet).</li>
+                                        <li>Once the record status is <strong>submitted</strong> or <strong>published</strong>, generating a DOI will automatically include the full metadata.</li>
+                                        <li><strong>Update DOI</strong> pushes the latest metadata to DataCite. This button is only enabled when the record is submitted or published.</li>
+                                        <li><strong>Delete DOI</strong> removes a draft DOI from DataCite (only available while the DOI is in draft status).</li>
+                                    </ol>
+                                }
+                                arrow
+                                placement="top"
+                            >
+                                <div style={{ display: "inline" }}>
+                                    <Button
+                                        onClick={() => handleGenerateDOI()}
+                                        disabled={generateDoiDisabled}
+                                        style={{ display: "inline", marginRight: "15px" }}
+                                    >
+                                        <div style={{ display: "flex", alignItems: "center" }}>
+                                            {loadingDoi ? (
+                                                <>
+                                                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                    Loading...
+                                                </>
+                                            ) : (
+                                                "Generate DOI"
+                                            )}
+                                        </div>
+                                    </Button>
+                                    {showUpdateDoi && (
+                                        <Button
+                                            onClick={() => handleUpdateDraftDOI()}
+                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status)}
+                                            style={{ display: 'inline', marginRight: "15px" }}
+                                        >
+                                            <div style={{ display: "flex", alignItems: "center" }}>
+                                                {loadingDoiUpdate ? (
+                                                    <>
+                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                        Loading...
+                                                    </>
+                                                ) : (
+                                                    "Update DOI"
+                                                )}
+                                            </div>
+                                        </Button>
+                                    )}
+                                    {showDeleteDoi && (
+                                        <Button
+                                            onClick={() => handleDeleteDOI()}
+                                            disabled={record.doiCreationStatus !== 'draft'}
+                                            style={{ display: "inline", marginRight: "15px" }}
+                                        >
+                                            <div style={{ display: "flex", alignItems: "center" }}>
+                                                {loadingDoiDelete ? (
+                                                    <>
+                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                        Loading...
+                                                    </>
+                                                ) : (
+                                                    "Delete DOI"
+                                                )}
+                                            </div>
+                                        </Button>
+                                    )}
+                                </div>
+                            </Tooltip>
+                        </En>
+                        <Fr>
+                            <Tooltip
+                                title={
+                                    <ol style={{ margin: 0, paddingLeft: "1.2em", fontSize: "0.85rem" }}>
+                                        <li><strong>Générer un DOI</strong> réserve un DOI brouillon auprès de DataCite (aucune métadonnée n&apos;est envoyée).</li>
+                                        <li>Lorsque le statut est <strong>soumis</strong> ou <strong>publié</strong>, la génération inclura automatiquement les métadonnées complètes.</li>
+                                        <li><strong>Mettre à jour le DOI</strong> envoie les métadonnées les plus récentes à DataCite. Activé uniquement lorsque soumis ou publié.</li>
+                                        <li><strong>Supprimer le DOI</strong> supprime un DOI brouillon de DataCite (disponible uniquement en statut brouillon).</li>
+                                    </ol>
+                                }
+                                arrow
+                                placement="top"
+                            >
+                                <div style={{ display: "inline" }}>
+                                    <Button
+                                        onClick={() => handleGenerateDOI()}
+                                        disabled={generateDoiDisabled}
+                                        style={{ display: "inline", marginRight: "15px" }}
+                                    >
+                                        <div style={{ display: "flex", alignItems: "center" }}>
+                                            {loadingDoi ? (
+                                                <>
+                                                    <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                    Loading...
+                                                </>
+                                            ) : (
+                                                "Generate DOI"
+                                            )}
+                                        </div>
+                                    </Button>
+                                    {showUpdateDoi && (
+                                        <Button
+                                            onClick={() => handleUpdateDraftDOI()}
+                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status)}
+                                            style={{ display: 'inline', marginRight: "15px" }}
+                                        >
+                                            <div style={{ display: "flex", alignItems: "center" }}>
+                                                {loadingDoiUpdate ? (
+                                                    <>
+                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                        Loading...
+                                                    </>
+                                                ) : (
+                                                    "Update DOI"
+                                                )}
+                                            </div>
+                                        </Button>
+                                    )}
+                                    {showDeleteDoi && (
+                                        <Button
+                                            onClick={() => handleDeleteDOI()}
+                                            disabled={record.doiCreationStatus !== 'draft'}
+                                            style={{ display: "inline", marginRight: "15px" }}
+                                        >
+                                            <div style={{ display: "flex", alignItems: "center" }}>
+                                                {loadingDoiDelete ? (
+                                                    <>
+                                                        <CircularProgress size={24} style={{ marginRight: "8px" }} />
+                                                        Loading...
+                                                    </>
+                                                ) : (
+                                                    "Delete DOI"
+                                                )}
+                                            </div>
+                                        </Button>
+                                    )}
+                                </div>
+                            </Tooltip>
+                        </Fr>
+                    </I18n>
                 )
             }
 

--- a/src/components/FormComponents/DOIInput.jsx
+++ b/src/components/FormComponents/DOIInput.jsx
@@ -290,7 +290,7 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
                                     {showUpdateDoi && (
                                         <Button
                                             onClick={() => handleUpdateDraftDOI()}
-                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status)}
+                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status) || loadingDoi || loadingDoiUpdate}
                                             style={{ display: 'inline', marginRight: "15px" }}
                                         >
                                             <div style={{ display: "flex", alignItems: "center" }}>
@@ -308,7 +308,7 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
                                     {showDeleteDoi && (
                                         <Button
                                             onClick={() => handleDeleteDOI()}
-                                            disabled={record.doiCreationStatus !== 'draft'}
+                                            disabled={record.doiCreationStatus !== 'draft' || loadingDoiDelete || loadingDoi}
                                             style={{ display: "inline", marginRight: "15px" }}
                                         >
                                             <div style={{ display: "flex", alignItems: "center" }}>
@@ -359,7 +359,7 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
                                     {showUpdateDoi && (
                                         <Button
                                             onClick={() => handleUpdateDraftDOI()}
-                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status)}
+                                            disabled={['not found', 'unknown'].includes(record.doiCreationStatus) || !["submitted", "published"].includes(record.status) || loadingDoi || loadingDoiUpdate}
                                             style={{ display: 'inline', marginRight: "15px" }}
                                         >
                                             <div style={{ display: "flex", alignItems: "center" }}>
@@ -377,7 +377,7 @@ const DOIInput = ({ record, name, handleUpdateDatasetIdentifier, handleUpdateDoi
                                     {showDeleteDoi && (
                                         <Button
                                             onClick={() => handleDeleteDOI()}
-                                            disabled={record.doiCreationStatus !== 'draft'}
+                                            disabled={record.doiCreationStatus !== 'draft' || loadingDoiDelete || loadingDoi}
                                             style={{ display: "inline", marginRight: "15px" }}
                                         >
                                             <div style={{ display: "flex", alignItems: "center" }}>

--- a/src/components/Pages/Admin.jsx
+++ b/src/components/Pages/Admin.jsx
@@ -21,7 +21,7 @@ import {
   FormLabel,
   Alert,
 } from "@mui/material";
-import { Save, Visibility, VisibilityOff } from "@mui/icons-material";
+import { Save, Delete, PlayArrow, Visibility, VisibilityOff } from "@mui/icons-material";
 import { getDatabase, ref, child, onValue, update, remove } from "firebase/database";
 import { Buffer } from 'buffer';
 
@@ -59,6 +59,8 @@ class Admin extends FormClassTemplate {
       showCredentialsMissingDialog: false,
       showErrorDialog: false,
       errorMessage: "",
+      testingCredentials: false,
+      testResult: null,
       githubOwner: "cioos-siooc",
       githubRepo: "cioos-siooc-forms",
       githubToken: "",
@@ -210,6 +212,117 @@ class Admin extends FormClassTemplate {
     }
   };
 
+  handleClearDataciteFields = async () => {
+    const { region } = this.props.match.params;
+
+    try {
+      const database = getDatabase(firebase);
+      await remove(ref(database, `admin/${region}/dataciteCredentials`));
+      this.setState({
+        datacitePrefix: "",
+        dataciteAccountId: "",
+        datacitePass: "",
+        dataciteApiDomain: "production",
+        credentialsStored: false,
+      });
+    } catch (error) {
+      this.setState({
+        showErrorDialog: true,
+        errorMessage: `Failed to clear DataCite credentials: ${error.message}`,
+      });
+    }
+  };
+
+  handleSaveDatacite = () => {
+    const { match } = this.props;
+    const { region } = match.params;
+    const {
+      datacitePrefix,
+      dataciteAccountId,
+      datacitePass,
+      dataciteApiDomain,
+      credentialsStored,
+    } = this.state;
+
+    if (!auth.currentUser) {
+      this.setState({
+        showErrorDialog: true,
+        errorMessage: "You must be logged in to save DataCite settings",
+      });
+      return;
+    }
+
+    // For new credentials, all fields are required
+    if (!credentialsStored && (!datacitePrefix || !dataciteAccountId || !datacitePass)) {
+      this.setState({ showCredentialsMissingDialog: true });
+      return;
+    }
+
+    // For updates, at least one field must be provided
+    if (credentialsStored && !datacitePrefix && !dataciteAccountId && !datacitePass && !dataciteApiDomain) {
+      this.setState({ showCredentialsMissingDialog: true });
+      return;
+    }
+
+    const database = getDatabase(firebase);
+    const updates = {};
+
+    if (datacitePrefix) {
+      updates["dataciteCredentials/prefix"] = datacitePrefix;
+    }
+
+    if (dataciteAccountId && datacitePass) {
+      const bufferObj = Buffer.from(
+        `${dataciteAccountId}:${datacitePass}`,
+        "utf8"
+      );
+      updates["dataciteCredentials/dataciteHash"] = bufferObj.toString("base64");
+    }
+
+    if (dataciteApiDomain) {
+      updates["dataciteCredentials/apiDomain"] = dataciteApiDomain;
+    }
+
+    const regionAdminRef = ref(database, `admin/${region}`);
+    update(regionAdminRef, updates)
+      .then(() => {
+        this.setState({
+          datacitePass: "",
+          dataciteAccountId: "",
+          credentialsStored: true,
+        });
+      })
+      .catch((error) => {
+        this.setState({
+          showErrorDialog: true,
+          errorMessage: `Failed to save DataCite settings: ${error.message}`,
+        });
+      });
+  };
+
+  handleTestCredentials = async () => {
+    const { region } = this.props.match.params;
+    const { testDataciteCredentials } = this.context;
+
+    this.setState({ testingCredentials: true, testResult: null });
+
+    try {
+      const result = await testDataciteCredentials(region);
+      this.setState({
+        testingCredentials: false,
+        testResult: { success: true, message: result.data.message },
+      });
+    } catch (error) {
+      this.setState({
+        testingCredentials: false,
+        testResult: {
+          success: false,
+          message: error.message || "Failed to connect to DataCite API.",
+        },
+      });
+    }
+  };
+
   handleSave() {
     const { match } = this.props;
     const { region } = match.params;
@@ -217,11 +330,6 @@ class Admin extends FormClassTemplate {
       reviewers,
       admins,
       projects,
-      datacitePrefix,
-      dataciteAccountId,
-      datacitePass,
-      dataciteApiDomain,
-      isDoiCreationEnabled,
       githubOwner,
       githubRepo,
       githubToken,
@@ -240,29 +348,7 @@ class Admin extends FormClassTemplate {
       updates["permissions/reviewers"] = cleanArr(reviewers).join();
       updates.projects = cleanArr(projects); // Save projects at the top level, not under permissions
 
-      // 2. DOI Credentials if enabled
-      if (isDoiCreationEnabled) {
-        if (!datacitePrefix || !dataciteAccountId || !datacitePass) {
-          this.setState({ showCredentialsMissingDialog: true });
-        } else {
-          const bufferObj = Buffer.from(
-            `${dataciteAccountId}:${datacitePass}`,
-            "utf8"
-          );
-          const base64String = bufferObj.toString("base64");
-
-          updates["dataciteCredentials/prefix"] = datacitePrefix;
-          updates["dataciteCredentials/dataciteHash"] = base64String;
-          updates["dataciteCredentials/apiDomain"] = dataciteApiDomain;
-
-          this.setState({
-            datacitePass: "",
-            credentialsStored: true,
-          });
-        }
-      }
-
-      // 3. GitHub Credentials
+      // 2. GitHub Credentials
       const githubCredentials = {
         owner: githubOwner,
         repo: githubRepo,
@@ -681,6 +767,59 @@ class Admin extends FormClassTemplate {
                         }}
                         fullWidth
                       />
+                    </Grid>
+                    {this.state.testResult && (
+                      <Grid size={12}>
+                        <Alert
+                          severity={this.state.testResult.success ? "success" : "error"}
+                          onClose={() => this.setState({ testResult: null })}
+                        >
+                          {this.state.testResult.message}
+                        </Alert>
+                      </Grid>
+                    )}
+                    <Grid size={12} container spacing={1} justifyContent="flex-end">
+                      <Grid>
+                        <Button
+                          startIcon={this.state.testingCredentials ? <CircularProgress size={20} /> : <PlayArrow />}
+                          variant="outlined"
+                          color="secondary"
+                          onClick={this.handleTestCredentials}
+                          disabled={!credentialsStored || this.state.testingCredentials}
+                        >
+                          <I18n>
+                            <En>Test Credentials</En>
+                            <Fr>Tester les identifiants</Fr>
+                          </I18n>
+                        </Button>
+                      </Grid>
+                      <Grid>
+                        <Button
+                          startIcon={<Delete />}
+                          variant="outlined"
+                          color="error"
+                          onClick={this.handleClearDataciteFields}
+                          disabled={!credentialsStored}
+                        >
+                          <I18n>
+                            <En>Clear DataCite Credentials</En>
+                            <Fr>Effacer les identifiants DataCite</Fr>
+                          </I18n>
+                        </Button>
+                      </Grid>
+                      <Grid>
+                        <Button
+                          startIcon={<Save />}
+                          variant="contained"
+                          color="primary"
+                          onClick={this.handleSaveDatacite}
+                        >
+                          <I18n>
+                            <En>{credentialsStored ? "Update" : "Save"} DataCite Settings</En>
+                            <Fr>{credentialsStored ? "Mettre à jour" : "Enregistrer"} les paramètres DataCite</Fr>
+                          </I18n>
+                        </Button>
+                      </Grid>
                     </Grid>
                   </>
                 )}

--- a/src/components/__tests__/DOIInput.test.jsx
+++ b/src/components/__tests__/DOIInput.test.jsx
@@ -267,4 +267,77 @@ describe("DOIInput", () => {
       expect(generateBtn).toBeDisabled();
     });
   });
+
+  describe("Update DOI button disabled during concurrent operations", () => {
+    it("should disable Update DOI while generate/auto-update is in progress", async () => {
+      const user = userEvent.setup();
+
+      // Make createDraftDoi hang so loadingDoi stays true
+      let resolveCreate;
+      mockCreateDraftDoi.mockImplementation(
+        () => new Promise((resolve) => { resolveCreate = resolve; })
+      );
+
+      renderDOIInput({
+        recordID: "rec-1",
+        doiCreationStatus: "draft",
+        datasetIdentifier: "https://doi.org/10.5678/existing",
+        status: "submitted",
+      });
+
+      // Update DOI button should be visible and initially enabled
+      const updateBtn = screen.getByRole("button", { name: /update doi/i });
+      expect(updateBtn).not.toBeDisabled();
+
+      // Click Generate DOI — it will hang on the create call
+      // We need a record where generate is allowed, but update is also shown
+      // Since doiCreationStatus is "draft", generate is disabled. Let's test via the update button's own loading state instead.
+
+      // Click Update DOI to start an update
+      let resolveUpdate;
+      mockPerformUpdateDraftDoi.mockImplementation(
+        () => new Promise((resolve) => { resolveUpdate = resolve; })
+      );
+
+      await user.click(updateBtn);
+
+      // While update is in progress, the button should be disabled
+      await waitFor(() => {
+        expect(updateBtn).toBeDisabled();
+      });
+
+      // Resolve the update to clean up
+      resolveUpdate(200);
+    });
+  });
+
+  describe("Delete DOI button disabled during concurrent operations", () => {
+    it("should disable Delete DOI while a delete is in-flight", async () => {
+      const user = userEvent.setup();
+
+      let resolveDelete;
+      mockDeleteDraftDoi.mockImplementation(
+        () => new Promise((resolve) => { resolveDelete = resolve; })
+      );
+
+      renderDOIInput({
+        recordID: "rec-1",
+        doiCreationStatus: "draft",
+        datasetIdentifier: "https://doi.org/10.5678/del-1",
+        status: "submitted",
+      });
+
+      const deleteBtn = screen.getByRole("button", { name: /delete doi/i });
+      expect(deleteBtn).not.toBeDisabled();
+
+      await user.click(deleteBtn);
+
+      await waitFor(() => {
+        expect(deleteBtn).toBeDisabled();
+      });
+
+      // Resolve to clean up
+      resolveDelete({ data: 204 });
+    });
+  });
 });

--- a/src/components/__tests__/DOIInput.test.jsx
+++ b/src/components/__tests__/DOIInput.test.jsx
@@ -1,0 +1,270 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UserContext } from "../../providers/UserProvider";
+
+// --- Mocks ---
+
+const mockCreateDraftDoi = vi.fn();
+const mockDeleteDraftDoi = vi.fn();
+const mockGetDoiStatus = vi.fn();
+const mockPerformUpdateDraftDoi = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ language: "en", region: "pacific", userID: "user1" }),
+  };
+});
+
+vi.mock("../../utils/doiUpdate", () => ({
+  default: (...args) => mockPerformUpdateDraftDoi(...args),
+}));
+
+// Import component after mocks
+const { default: DOIInput } = await import(
+  "../FormComponents/DOIInput"
+);
+
+// --- Helpers ---
+
+const baseRecord = {
+  identifier: "rec-1",
+  recordID: "rec-1",
+  datasetIdentifier: "",
+  doiCreationStatus: "",
+  status: "",
+  title: { en: "Test Dataset" },
+};
+
+function renderDOIInput(recordOverrides = {}, props = {}) {
+  const record = { ...baseRecord, ...recordOverrides };
+  const contextValue = {
+    createDraftDoi: mockCreateDraftDoi,
+    deleteDraftDoi: mockDeleteDraftDoi,
+    getDoiStatus: mockGetDoiStatus,
+    datacitePrefix: "10.5678",
+  };
+
+  return render(
+    <UserContext.Provider value={contextValue}>
+      <DOIInput
+        record={record}
+        name="datasetIdentifier"
+        handleUpdateDatasetIdentifier={props.handleUpdateDatasetIdentifier || vi.fn()}
+        handleUpdateDoiCreationStatus={props.handleUpdateDoiCreationStatus || vi.fn()}
+        disabled={false}
+        {...props}
+      />
+    </UserContext.Provider>
+  );
+}
+
+// --- Tests ---
+
+describe("DOIInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDoiStatus.mockResolvedValue({ data: "" });
+  });
+
+  describe("handleGenerateDOI – minimal payload", () => {
+    it("should call createDraftDoi with a minimal payload containing only the prefix", async () => {
+      const user = userEvent.setup();
+
+      mockCreateDraftDoi.mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              doi: "10.5678/test-suffix",
+              state: "draft",
+            },
+          },
+        },
+      });
+
+      renderDOIInput({ recordID: "rec-1", doiCreationStatus: "", status: "" });
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      await user.click(generateBtn);
+
+      await waitFor(() => {
+        expect(mockCreateDraftDoi).toHaveBeenCalledTimes(1);
+      });
+
+      const callArgs = mockCreateDraftDoi.mock.calls[0][0];
+      expect(callArgs).toEqual({
+        record: {
+          data: {
+            type: "dois",
+            attributes: {
+              prefix: "10.5678",
+            },
+          },
+        },
+        region: "pacific",
+      });
+    });
+
+    it("should update datasetIdentifier and doiCreationStatus after successful generation", async () => {
+      const user = userEvent.setup();
+      const handleUpdateDatasetIdentifier = vi.fn();
+      const handleUpdateDoiCreationStatus = vi.fn();
+
+      mockCreateDraftDoi.mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              doi: "10.5678/abc-123",
+              state: "draft",
+            },
+          },
+        },
+      });
+
+      renderDOIInput(
+        { recordID: "rec-1", doiCreationStatus: "", status: "" },
+        { handleUpdateDatasetIdentifier, handleUpdateDoiCreationStatus }
+      );
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      await user.click(generateBtn);
+
+      await waitFor(() => {
+        expect(handleUpdateDatasetIdentifier).toHaveBeenCalledWith({
+          target: { value: "https://doi.org/10.5678/abc-123" },
+        });
+        expect(handleUpdateDoiCreationStatus).toHaveBeenCalledWith({
+          target: { value: "draft" },
+        });
+      });
+    });
+  });
+
+  describe("auto-update on generate – submitted/published records", () => {
+    it("should call performUpdateDraftDoi when record status is 'submitted'", async () => {
+      const user = userEvent.setup();
+      mockPerformUpdateDraftDoi.mockResolvedValue(200);
+
+      mockCreateDraftDoi.mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              doi: "10.5678/sub-1",
+              state: "draft",
+            },
+          },
+        },
+      });
+
+      renderDOIInput({ recordID: "rec-1", doiCreationStatus: "", status: "submitted" });
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      await user.click(generateBtn);
+
+      await waitFor(() => {
+        expect(mockPerformUpdateDraftDoi).toHaveBeenCalledTimes(1);
+      });
+
+      const [updatedRecord, region, language, prefix] = mockPerformUpdateDraftDoi.mock.calls[0];
+      expect(updatedRecord.datasetIdentifier).toBe("https://doi.org/10.5678/sub-1");
+      expect(updatedRecord.doiCreationStatus).toBe("draft");
+      expect(region).toBe("pacific");
+      expect(language).toBe("en");
+      expect(prefix).toBe("10.5678");
+    });
+
+    it("should call performUpdateDraftDoi when record status is 'published'", async () => {
+      const user = userEvent.setup();
+      mockPerformUpdateDraftDoi.mockResolvedValue(200);
+
+      mockCreateDraftDoi.mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              doi: "10.5678/pub-1",
+              state: "draft",
+            },
+          },
+        },
+      });
+
+      renderDOIInput({ recordID: "rec-1", doiCreationStatus: "", status: "published" });
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      await user.click(generateBtn);
+
+      await waitFor(() => {
+        expect(mockPerformUpdateDraftDoi).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("should NOT call performUpdateDraftDoi when record status is empty (draft form)", async () => {
+      const user = userEvent.setup();
+
+      mockCreateDraftDoi.mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              doi: "10.5678/draft-1",
+              state: "draft",
+            },
+          },
+        },
+      });
+
+      renderDOIInput({ recordID: "rec-1", doiCreationStatus: "", status: "" });
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      await user.click(generateBtn);
+
+      await waitFor(() => {
+        expect(mockCreateDraftDoi).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockPerformUpdateDraftDoi).not.toHaveBeenCalled();
+    });
+
+    it("should show error alert when auto-update fails after generation", async () => {
+      const user = userEvent.setup();
+      mockPerformUpdateDraftDoi.mockRejectedValue(new Error("Update metadata failed"));
+
+      mockCreateDraftDoi.mockResolvedValue({
+        data: {
+          data: {
+            attributes: {
+              doi: "10.5678/fail-1",
+              state: "draft",
+            },
+          },
+        },
+      });
+
+      renderDOIInput({ recordID: "rec-1", doiCreationStatus: "", status: "submitted" });
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      await user.click(generateBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Update metadata failed/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Generate DOI button disabled state", () => {
+    it("should be disabled when doiCreationStatus is already set", () => {
+      renderDOIInput({ recordID: "rec-1", doiCreationStatus: "draft" });
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      expect(generateBtn).toBeDisabled();
+    });
+
+    it("should be disabled when recordID is empty", () => {
+      renderDOIInput({ recordID: "", doiCreationStatus: "" });
+
+      const generateBtn = screen.getByRole("button", { name: /generate doi/i });
+      expect(generateBtn).toBeDisabled();
+    });
+  });
+});

--- a/src/providers/UserProvider.jsx
+++ b/src/providers/UserProvider.jsx
@@ -107,6 +107,7 @@ class UserProviderClass extends FormClassTemplate {
     const checkURLActive = httpsCallable(functions, "checkURLActive");
     const getCredentialsStored = httpsCallable(functions, "getCredentialsStored");
     const getDatacitePrefix = httpsCallable(functions, "getDatacitePrefix");
+    const testDataciteCredentials = httpsCallable(functions, "testDataciteCredentials");
     const publishRecordToGitHub = httpsCallable(functions, "githubPublishRecord");
 
     return (
@@ -123,6 +124,7 @@ class UserProviderClass extends FormClassTemplate {
           checkURLActive,
           getCredentialsStored,
           getDatacitePrefix,
+          testDataciteCredentials,
           publishRecordToGitHub,
         }}
       >


### PR DESCRIPTION
This pull request introduces significant improvements to the DataCite DOI integration, focusing on credential management, user experience, and admin tooling. The main highlights are the addition of a backend endpoint to test DataCite credentials, enhancements to the DOI generation workflow, and a more intuitive admin UI for managing and validating DataCite credentials.

**Backend: DataCite Credential Management**

* Added a new Cloud Function `testDataciteCredentials` that attempts to create and delete a draft DOI to verify stored DataCite credentials and prefix, providing clear error feedback for authentication and permission issues.
* Exported `testDataciteCredentials` in the backend index for frontend access. [[1]](diffhunk://#diff-1bcc28b4e6450b8e46eb16b7ea9e0743d399b2226e10f84518d93c1cc6b8c241L4-R4) [[2]](diffhunk://#diff-1bcc28b4e6450b8e46eb16b7ea9e0743d399b2226e10f84518d93c1cc6b8c241R32)

**Frontend: DOI Generation and Metadata Workflow**

* Changed DOI generation in `DOIInput.jsx` to only reserve a draft DOI with minimal payload initially; if the record is already submitted or published, full metadata is pushed immediately after DOI creation. [[1]](diffhunk://#diff-0b9090e45722a1ee1026cee5e820832ed3564a143717f4ab4cbfd659d3f84a4dL60-R74) [[2]](diffhunk://#diff-0b9090e45722a1ee1026cee5e820832ed3564a143717f4ab4cbfd659d3f84a4dR101-R111)
* Improved UI/UX by adding tooltips (with English and French support) explaining the DOI workflow, and made the "Update DOI" button only enabled when the record status is "submitted" or "published". Also, added a "Delete DOI" button for draft DOIs. [[1]](diffhunk://#diff-0b9090e45722a1ee1026cee5e820832ed3564a143717f4ab4cbfd659d3f84a4dR259-R273) [[2]](diffhunk://#diff-0b9090e45722a1ee1026cee5e820832ed3564a143717f4ab4cbfd659d3f84a4dL255-R293) [[3]](diffhunk://#diff-0b9090e45722a1ee1026cee5e820832ed3564a143717f4ab4cbfd659d3f84a4dL275-R377) [[4]](diffhunk://#diff-0b9090e45722a1ee1026cee5e820832ed3564a143717f4ab4cbfd659d3f84a4dR394-R398) [[5]](diffhunk://#diff-0b9090e45722a1ee1026cee5e820832ed3564a143717f4ab4cbfd659d3f84a4dR7)

**Frontend: Admin Panel Enhancements**

* Refactored DataCite credential saving in the admin panel to separate save, test, and clear actions, providing better error handling and feedback. Added "Test Credentials" and "Clear Credentials" functionality, with clear success/error messages for credential validation. [[1]](diffhunk://#diff-901e916642ec2236763158b3b319bba8b823214ebf86968216f1e94d13b0c5f1L24-R24) [[2]](diffhunk://#diff-901e916642ec2236763158b3b319bba8b823214ebf86968216f1e94d13b0c5f1R62-R63) [[3]](diffhunk://#diff-901e916642ec2236763158b3b319bba8b823214ebf86968216f1e94d13b0c5f1L213-R351)

These changes make DataCite integration more robust, user-friendly, and easier to manage for both users and administrators.