### PR TITLE
Add back identifier forms table and card views

### DIFF
--- a/src/components/RecordList/MobileRecordRow.jsx
+++ b/src/components/RecordList/MobileRecordRow.jsx
@@ -37,6 +37,7 @@ const MobileRecordRow = ({
   const statusLabel = getStatusLabel(row.status, language);
   const dateDisplay = formatDate(row.created, language);
   const showProgress = config?.columns?.includes("progress");
+  const showIdentifier = config?.columns?.includes("identifier");
 
   return (
     <Box
@@ -75,6 +76,21 @@ const MobileRecordRow = ({
       >
         {row.title || (language === "en" ? "Untitled" : "Sans titre")}
       </Box>
+
+      {/* Identifier */}
+      {showIdentifier && row.identifier && (
+        <Box
+          sx={{
+            fontSize: "0.75rem",
+            color: "#999",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {row.identifier}
+        </Box>
+      )}
 
       {/* Author */}
       <Box sx={{ fontSize: "0.85rem", color: "#666" }}>

--- a/src/components/RecordList/config.jsx
+++ b/src/components/RecordList/config.jsx
@@ -17,8 +17,8 @@ export const reviewerConfig = {
     "progress",
     "created",
     "title",
-    "identifier",
     "author",
+    "identifier",
     "doi",
     "abstract",
     "license",
@@ -76,7 +76,7 @@ export const reviewerConfig = {
 
 export const publishedConfig = {
   pageId: "published",
-  columns: ["status", "created", "title", "identifier", "author"],
+  columns: ["status", "created", "title", "author", "identifier"],
 
   defaultColumnVisibility: {
     title: true,
@@ -110,7 +110,7 @@ export const publishedConfig = {
 
 export const submissionsConfig = {
   pageId: "submissions",
-  columns: ["status", "progress", "created", "title", "identifier", "author"],
+  columns: ["status", "progress", "created", "title", "author", "identifier"],
 
   defaultColumnVisibility: {
     title: true,

--- a/src/components/RecordList/config.jsx
+++ b/src/components/RecordList/config.jsx
@@ -17,6 +17,7 @@ export const reviewerConfig = {
     "progress",
     "created",
     "title",
+    "identifier",
     "author",
     "doi",
     "abstract",
@@ -38,6 +39,7 @@ export const reviewerConfig = {
     progress: true,
     created: true,
     doi: true,
+    identifier: false,
     abstract: false,
     license: false,
     verticalExtentMin: false,
@@ -74,13 +76,14 @@ export const reviewerConfig = {
 
 export const publishedConfig = {
   pageId: "published",
-  columns: ["status", "created", "title", "author"],
+  columns: ["status", "created", "title", "identifier", "author"],
 
   defaultColumnVisibility: {
     title: true,
     status: true,
     author: true,
     created: true,
+    identifier: false,
     actions: true,
   },
 
@@ -107,13 +110,14 @@ export const publishedConfig = {
 
 export const submissionsConfig = {
   pageId: "submissions",
-  columns: ["status", "progress", "created", "title", "author"],
+  columns: ["status", "progress", "created", "title", "identifier", "author"],
 
   defaultColumnVisibility: {
     title: true,
     status: true,
     progress: true,
     created: true,
+    identifier: false,
     author: false,
     actions: true,
   },
@@ -301,6 +305,24 @@ export const createColumns = (language, region) => ({
     flex: 2,
   },
 
+  identifier: {
+    field: "identifier",
+    headerName: language === "en" ? "Identifier" : "Identifiant",
+    flex: 1.5,
+    renderCell: (params) => (
+      <div
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+        title={params.value}
+      >
+        {params.value}
+      </div>
+    ),
+  },
+
   author: {
     field: "author",
     maxWidth: 200,
@@ -481,6 +503,7 @@ export const recordToRow = (record, language, index) => ({
   recordID: record.recordID,
   userID: record.userinfo?.userID,
   title: record.title?.[language] || "",
+  identifier: record.identifier || "",
   status: record.status || "",
   author: record.userinfo?.displayName || "",
   progress: Math.round(percentValid(record) * 100),


### PR DESCRIPTION
This pull request adds support for displaying a record's identifier in the record list views. The identifier is now available as an optional column across reviewer, published, and submissions pages. The changes include updates to the configuration, rendering logic, and data mapping to support this new column.

**New "Identifier" column support:**

* Added the "identifier" column to the `reviewerConfig`, `publishedConfig`, and `submissionsConfig` so it can be shown in those views. The column is hidden by default. [[1]](diffhunk://#diff-ab649f33b48015bad6d8aa85cec6b76998c0574e5d43a30a0c573e44903c8ae5R20) [[2]](diffhunk://#diff-ab649f33b48015bad6d8aa85cec6b76998c0574e5d43a30a0c573e44903c8ae5L77-R86) [[3]](diffhunk://#diff-ab649f33b48015bad6d8aa85cec6b76998c0574e5d43a30a0c573e44903c8ae5L110-R120)
* Updated the `defaultColumnVisibility` in all relevant configs to include `identifier: false`, making it available but not visible by default. [[1]](diffhunk://#diff-ab649f33b48015bad6d8aa85cec6b76998c0574e5d43a30a0c573e44903c8ae5R42) [[2]](diffhunk://#diff-ab649f33b48015bad6d8aa85cec6b76998c0574e5d43a30a0c573e44903c8ae5L77-R86) [[3]](diffhunk://#diff-ab649f33b48015bad6d8aa85cec6b76998c0574e5d43a30a0c573e44903c8ae5L110-R120)
* Added the "identifier" column definition to `createColumns`, with localized header and ellipsis styling for long values.

**Rendering and data mapping:**

* Updated `MobileRecordRow` to conditionally render the identifier field if the column is enabled and the record has an identifier, with appropriate styling. [[1]](diffhunk://#diff-d50edd29ef69e841d692b6507a82672bca88a1bdf7b70f65cc77e184ff9c7835R40) [[2]](diffhunk://#diff-d50edd29ef69e841d692b6507a82672bca88a1bdf7b70f65cc77e184ff9c7835R80-R94)
* Modified `recordToRow` to include the `identifier` property when mapping records to row data.