### PR TITLE
Add collection metadataScope

### DIFF
--- a/src/isoCodeLists.js
+++ b/src/isoCodeLists.js
@@ -249,17 +249,17 @@ export const metadataScopeCodes = {
   //   },
   //   isoValue: "document",
   // },
-  // Collection: {
-  //   title: {
-  //     en: "Collection",
-  //     fr: "Collection",
-  //   },
-  //   text: {
-  //     en: "An aggregation of resources, which may encompass collections of one resourceType as well as those of mixed types.A collection is described as a group; its parts may also be separately described.",
-  //     fr: "Agrégation de ressources, qui peut englober des collections d'un seul type de ressource ainsi que celles de types mixtes. Une collection est décrite comme un groupe ; ses parties peuvent également être décrites séparément.",
-  //   },
-  //   isoValue: "collection",
-  // },
+  Collection: {
+    title: {
+      en: "Collection",
+      fr: "Collection",
+    },
+    text: {
+      en: "An aggregation of resources, which may encompass collections of one resourceType as well as those of mixed types.A collection is described as a group; its parts may also be separately described.",
+      fr: "Agrégation de ressources, qui peut englober des collections d'un seul type de ressource ainsi que celles de types mixtes. Une collection est décrite comme un groupe ; ses parties peuvent également être décrites séparément.",
+    },
+    isoValue: "collection",
+  },
   // ComputationalNotebook: {
   //   title: {
   //     en: "Computational Notebook",


### PR DESCRIPTION
This pull request makes a small change to the `metadataScopeCodes` object in `src/isoCodeLists.js` by uncommenting and enabling the `Collection` entry. This means that the "Collection" metadata scope is now available for use in the application. 

* [`src/isoCodeLists.js`](diffhunk://#diff-3e710dcd3c7557e1cb9a6c3e9b084debddb30eb098d42b14f5edcdba10e198e9L252-R262): Uncommented and restored the `Collection` entry in `metadataScopeCodes`, making the "Collection" scope available with its English and French titles and descriptions.