### PR TITLE
Make platform association required for multiple instruments

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -314,10 +314,18 @@ const validators = {
   },
   instruments: {
     tab: "platformInstruments",
-    validation: (val) => val.every((instrument) => instrument.id),
+    validation: (val, record) => {
+      const platforms = record.platforms || [];
+      return val.every(
+        (instrument) =>
+          instrument.id && (platforms.length < 2 || instrument.platform)
+      );
+    },
     error: {
-      en: "Instrument ID is required",
-      fr: "L'identifiant de l'instrument est requis.",
+      en:
+        "Instrument ID is required. When multiple platforms are defined, each instrument must be associated to a platform.",
+      fr:
+        "L'identifiant de l'instrument est requis. Lorsque plusieurs plates-formes sont définies, chaque instrument doit être associé à une plate-forme.",
     },
   },
   taxa: {


### PR DESCRIPTION
This pull request updates the validation logic for instruments in `src/utils/validate.js` to ensure stricter checks when multiple platforms are defined. Now, each instrument must be associated with a platform if more than one platform exists, and the error messages have been updated to reflect this requirement.

Validation logic improvements:

* Updated the `instruments` validator to require that, when multiple platforms are defined, each instrument must be associated with a platform in addition to having an ID.

Error message enhancements:

* Improved the English and French error messages for the `instruments` validator to clarify the new requirement regarding platform association when multiple platforms are present.