### PR TITLE
Notify form submitters on submission

### DIFF
--- a/firebase-functions/functions/mailoutText.js
+++ b/firebase-functions/functions/mailoutText.js
@@ -79,6 +79,34 @@ function mailOptionsReviewer(
   };
 }
 
+function mailOptionsAuthorSubmissionConfirmation(
+  authorEmail,
+  titleEn,
+  titleFr,
+  region
+) {
+  const regionEn = (regionNames[region] || {}).en || region;
+  const regionFr = (regionNames[region] || {}).fr || region;
+
+  return {
+    from: "CIOOS Metadata Notifications <cioos.metadata.notifications@gmail.com>",
+    to: authorEmail,
+    subject: "Your CIOOS metadata record has been submitted",
+    html: `
+<p><b>Submission received</b></p>
+<p>Thank you for submitting your metadata record. ${regionEn} has been notified and will contact you if additional information is needed before your record is published.</p>
+${titleEn ? `<p>Title: ${titleEn}</p>` : ""}
+<p><a href="https://cioos-siooc.github.io/metadata-entry-form/#/en/${region}">Go to form</a></p>
+
+<hr>
+
+<p><b>Soumission reçue</b></p>
+<p>Merci d'avoir soumis votre enregistrement de métadonnées. ${regionFr} a été avisé et vous contactera si des informations supplémentaires sont nécessaires avant la publication de votre enregistrement.</p>
+${titleFr ? `<p>Titre : ${titleFr}</p>` : ""}
+<p><a href="https://cioos-siooc.github.io/metadata-entry-form/#/fr/${region}">Accéder au formulaire</a></p>`,
+  };
+}
+
 function mailOptionsAuthor(authorEmail, titleEn, titleFr, region) {
   return {
     from: "CIOOS Metadata Notifications <cioos.metadata.notifications@gmail.com>",
@@ -99,4 +127,8 @@ ${titleFr ? `<p>Titre : ${titleFr}</p>` : ""}
   };
 }
 
-module.exports = { mailOptionsReviewer, mailOptionsAuthor };
+module.exports = {
+  mailOptionsReviewer,
+  mailOptionsAuthor,
+  mailOptionsAuthorSubmissionConfirmation,
+};

--- a/firebase-functions/functions/mailoutText.js
+++ b/firebase-functions/functions/mailoutText.js
@@ -53,7 +53,8 @@ function mailOptionsReviewer(
     html: `
 <p><b>New record submitted for review</b></p>
 <table cellpadding="4">
-  ${row("Title", titleEn)}
+  ${row("Title (EN)", titleEn)}
+  ${row("Title (FR)", titleFr)}
   ${row("Submitted by", submittedBy)}
   ${row("Organization", orgName)}
   ${row("Region", regionEn)}
@@ -67,7 +68,8 @@ function mailOptionsReviewer(
 
 <p><b>Nouveau dossier soumis pour examen</b></p>
 <table cellpadding="4">
-  ${row("Titre", titleFr)}
+  ${row("Titre (EN)", titleEn)}
+  ${row("Titre (FR)", titleFr)}
   ${row("Soumis par", submittedBy)}
   ${row("Organisation", orgName)}
   ${row("Région", regionFr)}
@@ -95,14 +97,16 @@ function mailOptionsAuthorSubmissionConfirmation(
     html: `
 <p><b>Submission received</b></p>
 <p>Thank you for submitting your metadata record. ${regionEn} has been notified and will contact you if additional information is needed before your record is published.</p>
-${titleEn ? `<p>Title: ${titleEn}</p>` : ""}
+${titleEn ? `<p>Title (EN): ${titleEn}</p>` : ""}
+${titleFr ? `<p>Title (FR): ${titleFr}</p>` : ""}
 <p><a href="https://cioos-siooc.github.io/metadata-entry-form/#/en/${region}">Go to form</a></p>
 
 <hr>
 
 <p><b>Soumission reçue</b></p>
 <p>Merci d'avoir soumis votre enregistrement de métadonnées. ${regionFr} a été avisé et vous contactera si des informations supplémentaires sont nécessaires avant la publication de votre enregistrement.</p>
-${titleFr ? `<p>Titre : ${titleFr}</p>` : ""}
+${titleEn ? `<p>Titre (EN) : ${titleEn}</p>` : ""}
+${titleFr ? `<p>Titre (FR) : ${titleFr}</p>` : ""}
 <p><a href="https://cioos-siooc.github.io/metadata-entry-form/#/fr/${region}">Accéder au formulaire</a></p>`,
   };
 }
@@ -115,14 +119,16 @@ function mailOptionsAuthor(authorEmail, titleEn, titleFr, region) {
     html: `
 <p><b>Approved</b></p>
 <p>Your metadata record has been approved by a reviewer.</p>
-${titleEn ? `<p>Title: ${titleEn}</p>` : ""}
+${titleEn ? `<p>Title (EN): ${titleEn}</p>` : ""}
+${titleFr ? `<p>Title (FR): ${titleFr}</p>` : ""}
 <p><a href="https://cioos-siooc.github.io/metadata-entry-form/#/en/${region}">Go to form</a></p>
 
 <hr>
 
 <p><b>Approuvé</b></p>
 <p>Votre enregistrement de métadonnées a été approuvé par un réviseur.</p>
-${titleFr ? `<p>Titre : ${titleFr}</p>` : ""}
+${titleEn ? `<p>Titre (EN) : ${titleEn}</p>` : ""}
+${titleFr ? `<p>Titre (FR) : ${titleFr}</p>` : ""}
 <p><a href="https://cioos-siooc.github.io/metadata-entry-form/#/fr/${region}">Accéder au formulaire</a></p>`,
   };
 }

--- a/firebase-functions/functions/notify.js
+++ b/firebase-functions/functions/notify.js
@@ -2,7 +2,11 @@ const functions = require("firebase-functions");
 const admin = require("firebase-admin");
 const { defineString } = require('firebase-functions/params');
 const nodemailer = require("nodemailer");
-const { mailOptionsReviewer, mailOptionsAuthor } = require("./mailoutText");
+const {
+  mailOptionsReviewer,
+  mailOptionsAuthor,
+  mailOptionsAuthorSubmissionConfirmation,
+} = require("./mailoutText");
 const createIssue = require("./issue");
 
 /**
@@ -64,6 +68,22 @@ exports.notifyReviewer = functions.database
           `https://cioos-siooc.github.io/metadata-entry-form/#/${language}/${region}/${userID}/${recordID}`
         );
       }
+
+      console.log("Emailing submission confirmation to author", authorEmail);
+      transporter.sendMail(
+        mailOptionsAuthorSubmissionConfirmation(
+          authorEmail,
+          titleEn,
+          titleFr,
+          region
+        ),
+        (e, info) => {
+          console.log(info);
+          if (e) {
+            console.log(e);
+          }
+        }
+      );
 
       if (reviewers.includes(authorEmail)) {
         console.log("Author is a reviewer, don't notifiy other reviewers");

--- a/src/components/Tabs/SubmitTab.jsx
+++ b/src/components/Tabs/SubmitTab.jsx
@@ -9,6 +9,11 @@ import {
   Typography,
   Button,
   CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
 } from "@mui/material";
 
 import { useParams } from "react-router-dom";
@@ -31,6 +36,8 @@ const SubmitTab = ({ record, submitRecord, userID, doiUpdated, doiError }) => {
   const [isSubmitting, setSubmitting] = useState(false);
   const [validationWarnings, setValidationWarnings] = useState(false);
   const [showSubmitButton, setShowSubmitButton] = useState(false);
+  const [successDialogOpen, setSuccessDialogOpen] = useState(false);
+  const [errorDialogOpen, setErrorDialogOpen] = useState(false);
 
   const { language } = useParams();
 
@@ -188,11 +195,17 @@ const SubmitTab = ({ record, submitRecord, userID, doiUpdated, doiError }) => {
                     <Button
                       onClick={() => {
                         setSubmitting(true);
-                        submitRecord().then(() => {
-                          setSubmitting(false);
-                        });
+                        submitRecord()
+                          .then(() => {
+                            setSubmitting(false);
+                            setSuccessDialogOpen(true);
+                          })
+                          .catch(() => {
+                            setSubmitting(false);
+                            setErrorDialogOpen(true);
+                          });
                       }}
-                      disabled={submitted}
+                      disabled={submitted || isSubmitting}
                     >
                       <I18n>
                         <En>Submit</En>
@@ -307,6 +320,66 @@ const SubmitTab = ({ record, submitRecord, userID, doiUpdated, doiError }) => {
           </>
         )}
       </Grid>
+      <Dialog
+        open={successDialogOpen}
+        onClose={() => setSuccessDialogOpen(false)}
+      >
+        <DialogTitle>
+          <I18n>
+            <En>Submission received</En>
+            <Fr>Soumission reçue</Fr>
+          </I18n>
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            <I18n>
+              <En>
+                Your metadata form has been successfully submitted.{" "}
+                {regionInfo.title.en} has been notified and will contact you if
+                additional information is needed.
+              </En>
+              <Fr>
+                Votre formulaire de métadonnées a été soumis avec succès.{" "}
+                {regionInfo.title.fr} a été avisé et vous contactera si des
+                informations supplémentaires sont nécessaires.
+              </Fr>
+            </I18n>
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSuccessDialogOpen(false)}>OK</Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={errorDialogOpen}
+        onClose={() => setErrorDialogOpen(false)}
+      >
+        <DialogTitle>
+          <I18n>
+            <En>Submission failed</En>
+            <Fr>Échec de la soumission</Fr>
+          </I18n>
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            <I18n>
+              <En>
+                An error occurred while submitting your form. Please try again.
+                If the problem persists, contact{" "}
+              </En>
+              <Fr>
+                Une erreur s'est produite lors de la soumission de votre
+                formulaire. Veuillez réessayer. Si le problème persiste,
+                contactez{" "}
+              </Fr>
+            </I18n>
+            <a href={`mailto:${regionInfo.email}`}>{regionInfo.email}</a>.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setErrorDialogOpen(false)}>OK</Button>
+        </DialogActions>
+      </Dialog>
     </Paper>
   );
 };


### PR DESCRIPTION
## Summary
  - Send a dedicated bilingual confirmation email to the form creator when they submit a record (in addition to the existing reviewer notification)
  - Show a success dialog after submit (and an error dialog if the submit request fails)
  - Harden the submit button's `disabled` prop so it can't be re-clicked while the request is in flight
  - Include both English and French titles in every notification email, regardless of the form's selected language

  ## Why
  Partners weren't sure their forms had gone through and were submitting multiple times. They now get a direct confirmation email plus an immediate on-screen dialog. The bilingual titles let reviewers paste straight into Jira (which expects both EN and FR) without manual lookups

  ## Test plan
  - [ ] Submit a record in the `test` region and confirm the success dialog appears
  - [ ] Confirm both emails arrive: one to the reviewer list, one to the submitter
  - [ ] Submit as a user who is also a reviewer — confirm the submitter still gets their confirmation email
  - [ ] Simulate a submit failure (offline / reject) — confirm the error dialog appears
  - [ ] Confirm the Submit button is disabled while in-flight and not rendered after success
  - [ ] Submit a record with both EN and FR titles set — confirm all three emails (reviewer, submission confirmation, approval) show both `Title (EN)` and `Title (FR)` in both their EN and FR sections
  - [ ] Submit a record with only an EN title — confirm only the EN row appears (FR row gracefully omitted)
  
  ## Tickets:
  - https://github.com/cioos-siooc/metadata-entry-form/issues/491
  - https://github.com/cioos-siooc/metadata-entry-form/issues/496
  