### PR TITLE
Add test email notification functionality to admin panel

### DIFF
--- a/firebase-functions/functions/index.js
+++ b/firebase-functions/functions/index.js
@@ -2,7 +2,7 @@ const admin = require("firebase-admin");
 const { translate } = require("./translate");
 const { checkURLActive } = require("./serverUtils");
 const { createDraftDoi, updateDraftDoi, deleteDraftDoi, getDoiStatus, getCredentialsStored, getDatacitePrefix, testDataciteCredentials } = require("./datacite");
-const { notifyReviewer, notifyUser } = require("./notify");
+const { notifyReviewer, notifyUser, testEmailNotification } = require("./notify");
 const {
   updatesRecordCreate,
   updatesRecordUpdate,
@@ -17,6 +17,7 @@ admin.initializeApp();
 exports.translate = translate;
 exports.notifyReviewer = notifyReviewer;
 exports.notifyUser = notifyUser;
+exports.testEmailNotification = testEmailNotification;
 exports.updatesRecordUpdate = updatesRecordUpdate;
 exports.updatesRecordDelete = updatesRecordDelete;
 exports.updatesRecordCreate = updatesRecordCreate;

--- a/firebase-functions/functions/notify.js
+++ b/firebase-functions/functions/notify.js
@@ -21,6 +21,45 @@ const transporter = nodemailer.createTransport({
 /*
 Email the reviewers for the region when a form is submitted for review
 */
+// Send a test email to the calling admin's address to verify SMTP/credentials
+// from a deployed environment. Throws an HttpsError on transport failure.
+exports.testEmailNotification = functions.https.onCall(async (data, context) => {
+  if (!context.auth || !context.auth.token || !context.auth.token.email) {
+    throw new functions.https.HttpsError(
+      'unauthenticated',
+      'You must be signed in with a verified email to send a test email.'
+    );
+  }
+
+  const recipient = context.auth.token.email;
+  const region = (data && data.region) || 'unknown';
+
+  if (!gmailUserCred || !gmailPassCred) {
+    throw new functions.https.HttpsError(
+      'failed-precondition',
+      'Email credentials (GMAIL_USER / GMAIL_PASS) are not configured for this deployment.'
+    );
+  }
+
+  try {
+    const info = await transporter.sendMail({
+      from: gmailUserCred,
+      to: recipient,
+      subject: `[CIOOS Metadata] Test email for region "${region}"`,
+      text:
+        `This is a test email from the CIOOS metadata entry form.\n\n` +
+        `Region: ${region}\n` +
+        `Sent at: ${new Date().toISOString()}\n\n` +
+        `If you received this, the notification email pipeline is working.`,
+    });
+    functions.logger.info(`[testEmailNotification] Sent to ${recipient}`, { messageId: info.messageId });
+    return { success: true, recipient, messageId: info.messageId };
+  } catch (err) {
+    functions.logger.error('[testEmailNotification] sendMail failed:', err);
+    throw new functions.https.HttpsError('internal', err.message || 'Failed to send test email.');
+  }
+});
+
 exports.notifyReviewer = functions.database
   .ref("/{region}/users/{userID}/records/{recordID}/status")
   .onUpdate(async ({ after, before }, context) => {

--- a/src/components/Pages/Admin.jsx
+++ b/src/components/Pages/Admin.jsx
@@ -61,6 +61,8 @@ class Admin extends FormClassTemplate {
       errorMessage: "",
       testingCredentials: false,
       testResult: null,
+      testingEmail: false,
+      emailTestResult: null,
       githubOwner: "cioos-siooc",
       githubRepo: "cioos-siooc-forms",
       githubToken: "",
@@ -298,6 +300,32 @@ class Admin extends FormClassTemplate {
           errorMessage: `Failed to save DataCite settings: ${error.message}`,
         });
       });
+  };
+
+  handleTestEmail = async () => {
+    const { region } = this.props.match.params;
+    const { testEmailNotification } = this.context;
+
+    this.setState({ testingEmail: true, emailTestResult: null });
+
+    try {
+      const result = await testEmailNotification({ region });
+      this.setState({
+        testingEmail: false,
+        emailTestResult: {
+          success: true,
+          message: `Test email sent to ${result.data.recipient}. Check your inbox (and spam folder).`,
+        },
+      });
+    } catch (error) {
+      this.setState({
+        testingEmail: false,
+        emailTestResult: {
+          success: false,
+          message: error.message || "Failed to send test email.",
+        },
+      });
+    }
   };
 
   handleTestCredentials = async () => {
@@ -594,6 +622,30 @@ class Admin extends FormClassTemplate {
                     })
                   }
                 />
+              </Grid>
+              {this.state.emailTestResult && (
+                <Grid size={12}>
+                  <Alert
+                    severity={this.state.emailTestResult.success ? "success" : "error"}
+                    onClose={() => this.setState({ emailTestResult: null })}
+                  >
+                    {this.state.emailTestResult.message}
+                  </Alert>
+                </Grid>
+              )}
+              <Grid size={12} container justifyContent="flex-end">
+                <Button
+                  startIcon={this.state.testingEmail ? <CircularProgress size={20} /> : <PlayArrow />}
+                  variant="outlined"
+                  color="secondary"
+                  onClick={this.handleTestEmail}
+                  disabled={this.state.testingEmail}
+                >
+                  <I18n>
+                    <En>Send Test Email</En>
+                    <Fr>Envoyer un courriel de test</Fr>
+                  </I18n>
+                </Button>
               </Grid>
             </Paper>
             <Paper style={paperClass}>

--- a/src/providers/UserProvider.jsx
+++ b/src/providers/UserProvider.jsx
@@ -108,6 +108,7 @@ class UserProviderClass extends FormClassTemplate {
     const getCredentialsStored = httpsCallable(functions, "getCredentialsStored");
     const getDatacitePrefix = httpsCallable(functions, "getDatacitePrefix");
     const testDataciteCredentials = httpsCallable(functions, "testDataciteCredentials");
+    const testEmailNotification = httpsCallable(functions, "testEmailNotification");
     const publishRecordToGitHub = httpsCallable(functions, "githubPublishRecord");
 
     return (
@@ -125,6 +126,7 @@ class UserProviderClass extends FormClassTemplate {
           getCredentialsStored,
           getDatacitePrefix,
           testDataciteCredentials,
+          testEmailNotification,
           publishRecordToGitHub,
         }}
       >


### PR DESCRIPTION
## Description

Add functionality to send test email notifications from the admin panel to verify SMTP credentials and email configuration.

## Release Notes

Users can now send a test email from the admin panel to confirm that the email notification system is functioning correctly.

## Type of Change

- [x] `feature/` `enhancement/` `feat/` — New functionality
- [ ] `bug/` `fix/` — Bug fix
- [ ] `hotfix/` — Urgent production fix
- [ ] `refactor/` — Code restructuring
- [ ] `chore/` — Maintenance (deps, config)
- [ ] `docs/` `documentation/` — Documentation only
- [ ] `test/` — Adding or updating tests
- [ ] `style/` — Formatting, linting, cosmetic
- [ ] `perf/` `performance/` — Performance improvements
- [ ] `build/` — Build system or CI/CD changes
- [ ] `revert/` — Reverts a previous change

## How to Test

1. Navigate to the admin panel.
2. Click on the "Send Test Email" button.
3. Check the inbox of the email associated with your account for the test email.

