### PR TITLE
Fix notifyReviewer for sparse arrays and implement findCustodianOrgName

### DIFF
--- a/firebase-functions/functions/notify.js
+++ b/firebase-functions/functions/notify.js
@@ -75,7 +75,9 @@ exports.notifyReviewer = functions.database
       }
 
       const authorName = authorUserInfo.displayName || "";
-      const custodian = (record.contacts || []).find(
+      // RTDB returns sparse arrays as objects keyed by index, so coerce to a real array.
+      const contacts = Object.values(record.contacts || {});
+      const custodian = contacts.find(
         (c) => c.role && c.role.includes("custodian")
       );
       const orgName = custodian && custodian.orgName;

--- a/firebase-functions/functions/notify.js
+++ b/firebase-functions/functions/notify.js
@@ -23,10 +23,13 @@ const transporter = nodemailer.createTransport({
   auth: { user: gmailUserCred, pass: gmailPassCred },
 });
 // RTDB returns sparse arrays as objects keyed by index (e.g. {"0": ..., "2": ...}),
-// so callers cannot assume record.contacts is an Array. Coerce, then find the custodian's org.
+// so callers cannot assume record.contacts (or a contact's role) is an Array.
+// Coerce both with Object.values, then find the custodian's org.
 exports.findCustodianOrgName = (record) => {
   const contacts = Object.values((record && record.contacts) || {});
-  const custodian = contacts.find((c) => c && c.role && c.role.includes("custodian"));
+  const custodian = contacts.find((c) =>
+    Object.values((c && c.role) || {}).includes("custodian")
+  );
   return custodian && custodian.orgName;
 };
 

--- a/firebase-functions/functions/notify.js
+++ b/firebase-functions/functions/notify.js
@@ -18,6 +18,14 @@ const transporter = nodemailer.createTransport({
   service: "gmail",
   auth: { user: gmailUserCred, pass: gmailPassCred },
 });
+// RTDB returns sparse arrays as objects keyed by index (e.g. {"0": ..., "2": ...}),
+// so callers cannot assume record.contacts is an Array. Coerce, then find the custodian's org.
+exports.findCustodianOrgName = (record) => {
+  const contacts = Object.values((record && record.contacts) || {});
+  const custodian = contacts.find((c) => c && c.role && c.role.includes("custodian"));
+  return custodian && custodian.orgName;
+};
+
 /*
 Email the reviewers for the region when a form is submitted for review
 */
@@ -75,12 +83,7 @@ exports.notifyReviewer = functions.database
       }
 
       const authorName = authorUserInfo.displayName || "";
-      // RTDB returns sparse arrays as objects keyed by index, so coerce to a real array.
-      const contacts = Object.values(record.contacts || {});
-      const custodian = contacts.find(
-        (c) => c.role && c.role.includes("custodian")
-      );
-      const orgName = custodian && custodian.orgName;
+      const orgName = exports.findCustodianOrgName(record);
 
       console.log("Emailing ", reviewers);
       transporter.sendMail(

--- a/firebase-functions/functions/test/notify.test.js
+++ b/firebase-functions/functions/test/notify.test.js
@@ -1,0 +1,71 @@
+jest.mock("firebase-admin", () => ({
+  database: () => ({ ref: () => ({ once: jest.fn() }) }),
+}));
+
+jest.mock("firebase-functions", () => ({
+  database: { ref: () => ({ onUpdate: (fn) => fn }) },
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  https: {
+    onCall: (handler) => handler,
+    HttpsError: class extends Error {
+      constructor(code, message) { super(message); this.code = code; }
+    },
+  },
+}));
+
+jest.mock("firebase-functions/params", () => ({
+  defineString: () => ({ value: () => "" }),
+}));
+
+jest.mock("nodemailer", () => ({
+  createTransport: () => ({ sendMail: jest.fn() }),
+}));
+
+jest.mock("../issue", () => jest.fn());
+jest.mock("../mailoutText", () => ({
+  mailOptionsReviewer: jest.fn(),
+  mailOptionsAuthor: jest.fn(),
+}));
+
+const { findCustodianOrgName } = require("../notify");
+
+describe("findCustodianOrgName", () => {
+  test("finds custodian when contacts is an array (happy path)", () => {
+    const record = {
+      contacts: [
+        { role: ["owner"], orgName: "Other Org" },
+        { role: ["custodian"], orgName: "Custodian Org" },
+      ],
+    };
+    expect(findCustodianOrgName(record)).toBe("Custodian Org");
+  });
+
+  test("finds custodian when contacts is an object (RTDB sparse-array form — regression)", () => {
+    const record = {
+      contacts: {
+        0: { role: ["owner"], orgName: "Other Org" },
+        2: { role: ["custodian"], orgName: "Custodian Org" },
+      },
+    };
+    expect(findCustodianOrgName(record)).toBe("Custodian Org");
+  });
+
+  test("returns undefined when contacts is missing", () => {
+    expect(findCustodianOrgName({})).toBeUndefined();
+  });
+
+  test("returns undefined when no contact has the custodian role", () => {
+    const record = { contacts: [{ role: ["owner"], orgName: "Other" }] };
+    expect(findCustodianOrgName(record)).toBeUndefined();
+  });
+
+  test("tolerates contacts entries with no role field", () => {
+    const record = {
+      contacts: {
+        a: { orgName: "No Role" },
+        b: { role: ["custodian"], orgName: "Custodian Org" },
+      },
+    };
+    expect(findCustodianOrgName(record)).toBe("Custodian Org");
+  });
+});

--- a/firebase-functions/functions/test/notify.test.js
+++ b/firebase-functions/functions/test/notify.test.js
@@ -59,6 +59,19 @@ describe("findCustodianOrgName", () => {
     expect(findCustodianOrgName(record)).toBeUndefined();
   });
 
+  test("finds custodian when role is an object (RTDB sparse-array form — regression)", () => {
+    // RTDB returns role (an array of role strings) as an index-keyed object;
+    // a plain object has no .includes, which previously threw a TypeError and
+    // aborted the function before the reviewer email was sent.
+    const record = {
+      contacts: {
+        0: { role: { 0: "owner" }, orgName: "Other Org" },
+        1: { role: { 0: "custodian", 1: "owner" }, orgName: "Custodian Org" },
+      },
+    };
+    expect(findCustodianOrgName(record)).toBe("Custodian Org");
+  });
+
   test("tolerates contacts entries with no role field", () => {
     const record = {
       contacts: {


### PR DESCRIPTION
## Description

Fix notifyReviewer for sparse arrays and implement findCustodianOrgName

## Release Notes
 
This pull request improves how the custodian organization name is determined from a record's contacts, ensuring compatibility with both array and object (sparse array) forms returned by Firebase Realtime Database (RTDB). It introduces a new utility function for this logic and adds comprehensive unit tests to prevent regressions.

**Custodian Organization Extraction Improvements:**

* Added a new utility function `findCustodianOrgName` to `notify.js` that robustly extracts the custodian's organization name from `record.contacts`, handling both array and object (sparse array) formats as returned by RTDB.
* Updated the reviewer notification logic in `notifyReviewer` to use the new `findCustodianOrgName` function, improving reliability and code readability.

**Testing Enhancements:**

* Added a new test suite in `test/notify.test.js` for `findCustodianOrgName`, covering cases for array/object contacts, missing contacts, missing roles, and regression for sparse arrays.

## Type of Change

<!-- Label is auto-applied based on branch prefix (e.g., feature/, fix/, docs/).
     If your branch doesn't match a prefix, add a label manually. -->

- [ ] `feature/` `enhancement/` `feat/` — New functionality
- [x] `bug/` `fix/` — Bug fix
- [ ] `hotfix/` — Urgent production fix
- [ ] `refactor/` — Code restructuring
- [ ] `chore/` — Maintenance (deps, config)
- [ ] `docs/` `documentation/` — Documentation only
- [ ] `test/` — Adding or updating tests
- [ ] `style/` — Formatting, linting, cosmetic
- [ ] `perf/` `performance/` — Performance improvements
- [ ] `build/` — Build system or CI/CD changes
- [ ] `revert/` — Reverts a previous change

## How to Test

<!-- Steps to verify this change works correctly -->
