### PR TITLE
Fix Platform tab labels (en/fr)

### DIFF
--- a/src/components/FormComponents/Instruments.jsx
+++ b/src/components/FormComponents/Instruments.jsx
@@ -67,8 +67,8 @@ const Instruments = ({
               saveItem={saveUpdateInstrument}
               leftListHeader={<I18n><En>Instruments in this record:</En><Fr>Instruments dans cet enregistrement :</Fr></I18n>}
               leftListEmptyHeader={<I18n><En>There are no instruments in this record.</En><Fr>Il n'y a aucun instrument dans cet enregistrement.</Fr></I18n>}
-              addSavedItemLabel={<I18n><En>ADD SAVED INSTRUMENT</En><Fr>Ajouter un instrument enregistré</Fr></I18n>}
-              addNewItemText={<I18n><En>ADD NEW INSTRUMENT</En><Fr>Ajouter un instrument</Fr></I18n>}
+              addSavedItemLabel={<I18n><En>Add saved instrument</En><Fr>Ajouter un instrument enregistré</Fr></I18n>}
+              addNewItemText={<I18n><En>Add new instrument</En><Fr>Ajouter un instrument</Fr></I18n>}
               getBlankItem={getBlankInstrument}
               itemTitle={(instrumentItem) => InstrumentTitle({instrument:instrumentItem})}
               />

--- a/src/components/FormComponents/Platform.jsx
+++ b/src/components/FormComponents/Platform.jsx
@@ -57,7 +57,10 @@ const Platform = ({
                   savedUserItems={userPlatforms}
                   saveItem={saveUpdatePlatform}
                   getBlankItem={getBlankPlatform}
-                  addSavedItemLabel={<I18n en="ADD SAVED PLATFORM" fr="AJOUTER UNE PLATEFORME" />}
+                  leftListHeader={<I18n><En>Platforms in this record:</En><Fr>Plateformes dans cet enregistrement :</Fr></I18n>}
+                  leftListEmptyHeader={<I18n><En>There are no platforms in this record.</En><Fr>Il n'y a aucune plateforme dans cet enregistrement.</Fr></I18n>}
+                  addSavedItemLabel={<I18n><En>ADD SAVED PLATFORM</En><Fr>Ajouter une plateforme enregistrée</Fr></I18n>}
+                  addNewItemText={<I18n><En>ADD NEW PLATFORM</En><Fr>Ajouter une plateforme</Fr></I18n>}
                   itemTitle={(platformItem) => PlatformTitle({"platform":platformItem})}
                   />
 

--- a/src/components/FormComponents/Platform.jsx
+++ b/src/components/FormComponents/Platform.jsx
@@ -59,8 +59,8 @@ const Platform = ({
                   getBlankItem={getBlankPlatform}
                   leftListHeader={<I18n><En>Platforms in this record:</En><Fr>Plateformes dans cet enregistrement :</Fr></I18n>}
                   leftListEmptyHeader={<I18n><En>There are no platforms in this record.</En><Fr>Il n'y a aucune plateforme dans cet enregistrement.</Fr></I18n>}
-                  addSavedItemLabel={<I18n><En>ADD SAVED PLATFORM</En><Fr>Ajouter une plateforme enregistrée</Fr></I18n>}
-                  addNewItemText={<I18n><En>ADD NEW PLATFORM</En><Fr>Ajouter une plateforme</Fr></I18n>}
+                  addSavedItemLabel={<I18n><En>Add saved platform</En><Fr>Ajouter une plateforme enregistrée</Fr></I18n>}
+                  addNewItemText={<I18n><En>Add new platform</En><Fr>Ajouter une plateforme</Fr></I18n>}
                   itemTitle={(platformItem) => PlatformTitle({"platform":platformItem})}
                   />
 


### PR DESCRIPTION
## Fix Platform tab labels (en/fr)

### Problem
A user reported inconsistent labels in the **Platform** tab:
- **FR:** the "add new platform" button read **"AJOUTER UN CONTACT"** instead of "Ajouter une plateforme".
- **FR:** the saved-platform dropdown read **"AJOUTER UNE PLATEFORME"** instead of **"Ajouter une plateforme enregistrée"** (to match the instrument section).
- **EN:** the section alternated between "PLATFORM" and "ITEM" — e.g. "There are no items in this record", "ADD NEW ITEM", "Items in this record:".

### Root cause
`Platform.jsx` renders the shared `LeftList` component but only passed `addSavedItemLabel` (with incomplete French). The other label props (`addNewItemText`, `leftListHeader`, `leftListEmptyHeader`) were omitted, so `LeftList` fell back to its hardcoded contact/item-flavored defaults. The sibling `Instruments.jsx` already passes all four props correctly.

### Change
Updated the `<LeftList>` call in `src/components/FormComponents/Platform.jsx` to pass platform-specific labels in both languages, mirroring the `Instruments.jsx` pattern:
- Add-new button → `ADD NEW PLATFORM` / `Ajouter une plateforme`
- Saved dropdown → `ADD SAVED PLATFORM` / `Ajouter une plateforme enregistrée`
- List header → `Platforms in this record:` / `Plateformes dans cet enregistrement :`
- Empty header → `There are no platforms in this record.` / `Il n'y a aucune plateforme dans cet enregistrement.`

No changes to `LeftList.jsx` defaults, which are shared with other consumers (e.g. Contacts).

### Testing
- `npm test` — all 76 tests pass.
- Verified the Platform tab in both languages shows platform-specific wording with no remaining "ITEM"/"CONTACT" labels.
