### PR TITLE
Fix resource type / scope code not lowercase in harvested metadata

### DIFF
--- a/src/__tests__/isoCodeList.test.js
+++ b/src/__tests__/isoCodeList.test.js
@@ -1,4 +1,4 @@
-import { eovList, progressCodes, roleCodes, associationTypeCode, initiativeTypeCode } from "../isoCodeLists";
+import { eovList, progressCodes, roleCodes, associationTypeCode, initiativeTypeCode, metadataScopeCodes } from "../isoCodeLists";
 
 it("Defines constants", () => {
   expect(eovList).toBeDefined();
@@ -6,4 +6,12 @@ it("Defines constants", () => {
   expect(roleCodes).toBeDefined();
   expect(associationTypeCode).toBeDefined();
   expect(initiativeTypeCode).toBeDefined();
+});
+
+it("Uses lowerCamelCase ISO MD_ScopeCode values", () => {
+  // ISO 19115 MD_ScopeCode values must start lowercase (lowerCamelCase for
+  // multi-word codes) so CKAN harvests them, e.g. "dataset", "collectionSession".
+  Object.values(metadataScopeCodes).forEach(({ isoValue }) => {
+    expect(isoValue).toMatch(/^[a-z][a-zA-Z]*$/);
+  });
 });

--- a/src/components/Pages/MetadataForm.jsx
+++ b/src/components/Pages/MetadataForm.jsx
@@ -592,7 +592,7 @@ class MetadataForm extends FormClassTemplate {
                 label={tabs.resources[language]}
                 value="distribution"
               />
-              {!["model"].includes(record.metadataScope) && (
+              {!["model"].includes(record.metadataScopeIso) && (
                 <Tab
                   fullWidth
                   classes={{ root: classes.tabRoot }}

--- a/src/components/Tabs/StartTab.jsx
+++ b/src/components/Tabs/StartTab.jsx
@@ -76,6 +76,14 @@ const StartTab = ({ disabled, record, updateRecord, handleUpdateRecord, userID }
 
     if (!record.metadataScope) {
       handleUpdateRecord("metadataScope")({ target: { value: 'Dataset' } });
+      handleUpdateRecord("metadataScopeIso")({
+        target: { value: metadataScopeCodes.Dataset.isoValue },
+      });
+    } else if (!record.metadataScopeIso && metadataScopeCodes[record.metadataScope]) {
+      // Backfill ISO value for records saved before this fix
+      handleUpdateRecord("metadataScopeIso")({
+        target: { value: metadataScopeCodes[record.metadataScope].isoValue },
+      });
     }
 
     return () => {

--- a/src/components/Tabs/__tests__/StartTab.test.jsx
+++ b/src/components/Tabs/__tests__/StartTab.test.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import StartTab from "../StartTab";
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ language: "en", region: "pacific" }),
+  };
+});
+
+// SharedUsersList fetches region users from Firebase, which is unavailable in
+// jsdom. Stub it out so the test focuses on the resource-scope defaulting logic.
+vi.mock("../../FormComponents/SharedUsersList", () => ({
+  default: () => null,
+}));
+
+const theme = createTheme();
+
+const renderStartTab = (record) => {
+  const handleUpdateRecord = vi.fn(() => vi.fn());
+  render(
+    <ThemeProvider theme={theme}>
+      <MemoryRouter>
+        <StartTab
+          disabled={false}
+          record={record}
+          updateRecord={() => () => {}}
+          handleUpdateRecord={handleUpdateRecord}
+          userID="user1"
+        />
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+  return handleUpdateRecord;
+};
+
+// Collect the values passed to handleUpdateRecord(key)(event) for a given key.
+const valuesFor = (handleUpdateRecord, key) =>
+  handleUpdateRecord.mock.results
+    .filter((_, i) => handleUpdateRecord.mock.calls[i][0] === key)
+    .flatMap((res) => res.value.mock.calls.map((c) => c[0].target.value));
+
+describe("<StartTab /> metadata scope defaults", () => {
+  it("sets metadataScopeIso to 'dataset' when no scope is present", () => {
+    const handleUpdateRecord = renderStartTab({ eov: [], map: {} });
+
+    expect(valuesFor(handleUpdateRecord, "metadataScope")).toContain("Dataset");
+    expect(valuesFor(handleUpdateRecord, "metadataScopeIso")).toContain(
+      "dataset"
+    );
+  });
+
+  it("backfills metadataScopeIso from metadataScope for legacy records", () => {
+    const handleUpdateRecord = renderStartTab({
+      metadataScope: "Model",
+      eov: [],
+      map: {},
+    });
+
+    expect(valuesFor(handleUpdateRecord, "metadataScopeIso")).toContain("model");
+  });
+
+  it("does not overwrite an existing metadataScopeIso", () => {
+    const handleUpdateRecord = renderStartTab({
+      metadataScope: "Dataset",
+      metadataScopeIso: "dataset",
+      eov: [],
+      map: {},
+    });
+
+    expect(valuesFor(handleUpdateRecord, "metadataScopeIso")).toEqual([]);
+  });
+});

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -307,7 +307,7 @@ const validators = {
   },
   platforms: {
     tab: "platform",
-    validation: (val, record) => record.noPlatform || val.every((platform) => platform.type && platform.id) || (!record.metadataScope || record.metadataScope === 'model'),
+    validation: (val, record) => record.noPlatform || val.every((platform) => platform.type && platform.id) || (!record.metadataScope || record.metadataScopeIso === 'model'),
     error: {
       en: "Missing platform type or ID",
       fr: "Type ou ID de plateforme manquant.",


### PR DESCRIPTION
## Fix resource type / scope code not lowercase in harvested metadata

### Problem
Records created with the default resource type **Dataset** harvested into CKAN with a capitalized scope (`Dataset`) instead of the ISO-compliant lowercase `dataset`. CKAN (e.g. Atlantic CKAN) and the ISO 19115 `MD_ScopeCode` codelist expect lowercase values (lowerCamelCase for multi-word codes), so affected records were silently skipped during harvest.

### Root cause
The form keeps two parallel fields: `metadataScope` (capitalized display key, e.g. `"Dataset"`) and `metadataScopeIso` (lowercase ISO value, e.g. `"dataset"`). The dropdown handler in `StartTab.jsx` sets both, but the default-initialization set only `metadataScope`. The production conversion (`cioos-metadata-conversion` → `firebase_to_cioos.py`) does `record.get("metadataScopeIso") or record.get("metadataScope")`, so a missing `metadataScopeIso` fell back to the capitalized value.

### Changes
- **`src/components/Tabs/StartTab.jsx`** — the default `useEffect` now also sets `metadataScopeIso` to `'dataset'`, and backfills `metadataScopeIso` from `metadataScope` for legacy records when they are opened.
- **`src/utils/validate.js`** & **`src/components/Pages/MetadataForm.jsx`** — fixed two latent bugs from the same field split that compared `metadataScope` (now `"Model"`) against the lowercase `'model'`; they now compare `metadataScopeIso`.
- **Tests** — new `src/components/Tabs/__tests__/StartTab.test.jsx` (default + backfill + no-overwrite) and a lowerCamelCase sanity check for all `metadataScopeCodes` ISO values in `isoCodeList.test.js`.

### Follow-up (not in this PR)
Already-published records keep harvesting as `Dataset` until re-opened and saved (the form backfills them on open). A one-time Firebase backfill of `metadataScopeIso` would clear them immediately.

### Testing
- `npm test` — all 80 tests pass.
